### PR TITLE
Add Gutenberg-ready PoeTheme WordPress theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # PoeTheme
-Tema WordPress con tailwindcss, alpinejs, Lucide Icons
+
+Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'editor a blocchi di Gutenberg.
+
+## Caratteristiche principali
+- Integrazione con Tailwind CSS, Alpine.js e Lucide Icons tramite CDN.
+- Layout semantico HTML5 con header, nav, main, article, aside e footer.
+- Breadcrumbs accessibili con markup Schema.org e JSON-LD per SEO avanzata.
+- Ottimizzato per l'accessibilità (skip link, focus visibili, alt text automatico, navigazione da tastiera).
+- Compatibile con RTL, traduzioni tramite file POT e widget-ready (sidebar e footer).
+- Opzioni tema dedicate (Generale e Logo) per personalizzare tagline, breadcrumb e branding.
+
+## Struttura cartelle
+- `inc/` funzioni di supporto e opzioni tema.
+- `assets/css/` stili dedicati all'editor a blocchi.
+- `languages/` file di traduzione `.pot`.
+
+## Requisiti
+- WordPress 6.0 o superiore.
+- PHP 7.4 o superiore.
+
+## Installazione
+1. Copia la cartella del tema in `wp-content/themes/poetheme`.
+2. Attiva il tema da **Aspetto → Temi**.
+3. Configura le opzioni aggiuntive da **Aspetto → PoeTheme Options**.
+
+## Licenza
+Distribuito sotto licenza GPL v2 o successiva.

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -1,0 +1,24 @@
+/* Editor styles for PoeTheme */
+body.block-editor-page .editor-styles-wrapper {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #111827;
+}
+
+body.block-editor-page .editor-styles-wrapper .wp-block {
+  max-width: 720px;
+}
+
+body.block-editor-page .editor-styles-wrapper a {
+  color: #2563eb;
+}
+
+body.block-editor-page .editor-styles-wrapper a:focus {
+  outline: 3px solid #1e40af;
+  outline-offset: 2px;
+}
+
+body.block-editor-page .editor-styles-wrapper .wp-block-button__link {
+  background-color: #2563eb;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1.5rem;
+}

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Comments template.
+ *
+ * @package PoeTheme
+ */
+
+if ( post_password_required() ) {
+    return;
+}
+?>
+<section id="comments" class="mt-10" aria-labelledby="comments-title">
+    <?php if ( have_comments() ) : ?>
+        <h2 id="comments-title" class="text-2xl font-semibold mb-6">
+            <?php
+            printf(
+                esc_html( _n( '%1$s Comment', '%1$s Comments', get_comments_number(), 'poetheme' ) ),
+                number_format_i18n( get_comments_number() )
+            );
+            ?>
+        </h2>
+
+        <ol class="space-y-6">
+            <?php
+            wp_list_comments(
+                array(
+                    'style'      => 'ol',
+                    'short_ping' => true,
+                    'avatar_size'=> 64,
+                    'callback'   => null,
+                )
+            );
+            ?>
+        </ol>
+
+        <?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
+            <nav class="comment-navigation mt-6" aria-label="<?php esc_attr_e( 'Comments navigation', 'poetheme' ); ?>">
+                <div class="flex justify-between">
+                    <div><?php previous_comments_link( esc_html__( 'Older Comments', 'poetheme' ) ); ?></div>
+                    <div><?php next_comments_link( esc_html__( 'Newer Comments', 'poetheme' ) ); ?></div>
+                </div>
+            </nav>
+        <?php endif; ?>
+    <?php endif; ?>
+
+    <?php if ( ! comments_open() && get_comments_number() ) : ?>
+        <p class="text-sm text-gray-500"><?php esc_html_e( 'Comments are closed.', 'poetheme' ); ?></p>
+    <?php endif; ?>
+
+    <?php
+    comment_form(
+        array(
+            'title_reply_before' => '<h2 id="reply-title" class="text-xl font-semibold mt-8">',
+            'title_reply_after'  => '</h2>',
+            'class_submit'       => 'bg-indigo-600 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-4 focus:ring-indigo-300',
+        )
+    );
+    ?>
+</section>

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Footer template.
+ *
+ * @package PoeTheme
+ */
+?>
+    </main>
+
+    <aside class="bg-gray-100 border-t border-gray-200" aria-label="<?php esc_attr_e( 'Footer widgets', 'poetheme' ); ?>">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 grid gap-8 md:grid-cols-2">
+            <?php if ( is_active_sidebar( 'footer-1' ) ) : ?>
+                <?php dynamic_sidebar( 'footer-1' ); ?>
+            <?php else : ?>
+                <section class="text-sm text-gray-600" role="presentation">
+                    <h2 class="font-semibold text-gray-800"><?php esc_html_e( 'Widget Area', 'poetheme' ); ?></h2>
+                    <p><?php esc_html_e( 'Add widgets in the WordPress admin to replace this placeholder.', 'poetheme' ); ?></p>
+                </section>
+            <?php endif; ?>
+        </div>
+    </aside>
+
+    <footer class="bg-white border-t border-gray-200" role="contentinfo">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <p class="text-sm text-gray-600">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?></p>
+            <nav aria-label="<?php esc_attr_e( 'Footer navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'footer',
+                        'menu_class'     => 'flex gap-4 text-sm',
+                        'container'      => false,
+                        'fallback_cb'    => false,
+                    )
+                );
+                ?>
+            </nav>
+        </div>
+    </footer>
+
+    <?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * PoeTheme functions and definitions
+ *
+ * @package PoeTheme
+ */
+
+define( 'POETHEME_VERSION', '1.0.0' );
+
+define( 'POETHEME_DIR', get_template_directory() );
+define( 'POETHEME_URI', get_template_directory_uri() );
+
+require_once POETHEME_DIR . '/inc/theme-options.php';
+require_once POETHEME_DIR . '/inc/template-tags.php';
+
+if ( ! function_exists( 'poetheme_setup' ) ) {
+    /**
+     * Setup theme defaults and registers support for WordPress features.
+     */
+    function poetheme_setup() {
+        load_theme_textdomain( 'poetheme', POETHEME_DIR . '/languages' );
+
+        add_theme_support( 'automatic-feed-links' );
+        add_theme_support( 'title-tag' );
+        add_theme_support( 'post-thumbnails' );
+        add_theme_support( 'align-wide' );
+        add_theme_support( 'responsive-embeds' );
+        add_theme_support( 'wp-block-styles' );
+        add_theme_support( 'editor-styles' );
+        add_editor_style( 'assets/css/editor.css' );
+
+        register_nav_menus(
+            array(
+                'primary' => __( 'Primary Menu', 'poetheme' ),
+                'footer'  => __( 'Footer Menu', 'poetheme' ),
+            )
+        );
+
+        add_theme_support(
+            'html5',
+            array(
+                'search-form',
+                'comment-form',
+                'comment-list',
+                'gallery',
+                'caption',
+                'style',
+                'script',
+                'navigation-widgets',
+            )
+        );
+
+        add_theme_support(
+            'custom-logo',
+            array(
+                'height'      => 120,
+                'width'       => 480,
+                'flex-height' => true,
+                'flex-width'  => true,
+            )
+        );
+
+        add_theme_support( 'customize-selective-refresh-widgets' );
+        add_theme_support( 'custom-spacing' );
+
+        add_theme_support( 'editor-color-palette', array() );
+        add_theme_support( 'editor-gradient-presets', array() );
+
+        add_theme_support( 'rtl-language-support' );
+    }
+}
+add_action( 'after_setup_theme', 'poetheme_setup' );
+
+/**
+ * Register widget areas.
+ */
+function poetheme_widgets_init() {
+    register_sidebar(
+        array(
+            'name'          => __( 'Sidebar', 'poetheme' ),
+            'id'            => 'sidebar-1',
+            'description'   => __( 'Add widgets here.', 'poetheme' ),
+            'before_widget' => '<section id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</section>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        )
+    );
+
+    register_sidebar(
+        array(
+            'name'          => __( 'Footer Widgets', 'poetheme' ),
+            'id'            => 'footer-1',
+            'description'   => __( 'Appears in the footer widget area.', 'poetheme' ),
+            'before_widget' => '<section id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</section>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        )
+    );
+}
+add_action( 'widgets_init', 'poetheme_widgets_init' );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function poetheme_scripts() {
+    wp_enqueue_style( 'poetheme-tailwind', 'https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css', array(), POETHEME_VERSION );
+    wp_enqueue_style( 'poetheme-style', get_stylesheet_uri(), array( 'poetheme-tailwind' ), POETHEME_VERSION );
+
+    wp_enqueue_script( 'poetheme-alpine', 'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js', array(), POETHEME_VERSION, true );
+    wp_script_add_data( 'poetheme-alpine', 'defer', true );
+
+    wp_enqueue_script( 'poetheme-lucide', 'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', array(), POETHEME_VERSION, true );
+    wp_script_add_data( 'poetheme-lucide', 'defer', true );
+
+    wp_add_inline_script(
+        'poetheme-lucide',
+        'document.addEventListener("DOMContentLoaded",function(){if(window.lucide){window.lucide.createIcons();}});'
+    );
+}
+add_action( 'wp_enqueue_scripts', 'poetheme_scripts' );
+
+/**
+ * Block editor assets.
+ */
+function poetheme_block_editor_assets() {
+    wp_enqueue_style( 'poetheme-editor-tailwind', 'https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css', array(), POETHEME_VERSION );
+    wp_enqueue_style( 'poetheme-editor-style', POETHEME_URI . '/assets/css/editor.css', array( 'poetheme-editor-tailwind' ), POETHEME_VERSION );
+    wp_enqueue_script( 'poetheme-editor-alpine', 'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js', array(), POETHEME_VERSION, true );
+    wp_script_add_data( 'poetheme-editor-alpine', 'defer', true );
+}
+add_action( 'enqueue_block_editor_assets', 'poetheme_block_editor_assets' );
+
+/**
+ * Output structured data and breadcrumbs schema.
+ */
+function poetheme_output_schema() {
+    if ( is_admin() ) {
+        return;
+    }
+
+    $breadcrumbs = poetheme_get_breadcrumbs_items();
+
+    $schema = array(
+        '@context'        => 'https://schema.org',
+        '@type'           => 'WebSite',
+        'name'            => get_bloginfo( 'name' ),
+        'url'             => home_url(),
+        'potentialAction' => array(
+            '@type'       => 'SearchAction',
+            'target'      => home_url( '?s={search_term_string}' ),
+            'query-input' => 'required name=search_term_string',
+        ),
+    );
+
+    if ( ! empty( $breadcrumbs ) ) {
+        $schema_breadcrumbs = array(
+            '@context'        => 'https://schema.org',
+            '@type'           => 'BreadcrumbList',
+            'itemListElement' => array(),
+        );
+
+        foreach ( $breadcrumbs as $index => $breadcrumb ) {
+            $list_item = array(
+                '@type'    => 'ListItem',
+                'position' => $index + 1,
+                'name'     => wp_strip_all_tags( $breadcrumb['label'] ),
+            );
+
+            if ( ! empty( $breadcrumb['url'] ) ) {
+                $list_item['item'] = esc_url_raw( $breadcrumb['url'] );
+            }
+
+            $schema_breadcrumbs['itemListElement'][] = $list_item;
+        }
+
+        echo '<script type="application/ld+json">' . wp_json_encode( $schema_breadcrumbs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</script>';
+    }
+
+    echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</script>';
+}
+add_action( 'wp_head', 'poetheme_output_schema', 20 );
+
+/**
+ * Add body classes.
+ */
+function poetheme_body_classes( $classes ) {
+    if ( is_rtl() ) {
+        $classes[] = 'rtl';
+    }
+
+    return $classes;
+}
+add_filter( 'body_class', 'poetheme_body_classes' );
+
+/**
+ * Ensure images have alt text.
+ */
+function poetheme_attachment_alt_text( $attr, $attachment ) {
+    if ( empty( $attr['alt'] ) ) {
+        $attr['alt'] = get_the_title( $attachment );
+    }
+
+    return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'poetheme_attachment_alt_text', 10, 2 );
+
+/**
+ * Add skip link target support.
+ */
+function poetheme_skip_link_target() {
+    echo '<a class="skip-link" href="#primary-content">' . esc_html__( 'Skip to content', 'poetheme' ) . '</a>';
+}
+add_action( 'poetheme_before_header', 'poetheme_skip_link_target' );

--- a/header.php
+++ b/header.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Header template.
+ *
+ * @package PoeTheme
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?> class="scroll-smooth">
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php
+    $options = poetheme_get_options();
+    $description = ! empty( $options['tagline'] ) ? $options['tagline'] : get_bloginfo( 'description', 'display' );
+    if ( $description ) {
+        echo '<meta name="description" content="' . esc_attr( $description ) . '">';
+    }
+    ?>
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class( 'bg-gray-50 text-gray-900 leading-relaxed' ); ?>>
+<?php wp_body_open(); ?>
+<?php do_action( 'poetheme_before_header' ); ?>
+<header class="bg-white shadow-sm" role="banner">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="flex items-center gap-4">
+            <?php poetheme_the_logo(); ?>
+            <p class="text-sm text-gray-600" id="site-description"><?php echo esc_html( get_bloginfo( 'description' ) ); ?></p>
+        </div>
+        <nav class="nav-primary" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+            <?php
+            wp_nav_menu(
+                array(
+                    'theme_location' => 'primary',
+                    'menu_class'     => 'flex flex-wrap gap-4 text-base font-medium',
+                    'container'      => false,
+                    'fallback_cb'    => 'wp_page_menu',
+                )
+            );
+            ?>
+        </nav>
+    </div>
+</header>
+
+<main id="primary-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10" tabindex="-1">
+    <?php poetheme_the_breadcrumbs(); ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Template tags and helpers.
+ *
+ * @package PoeTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Get breadcrumbs items.
+ *
+ * @return array
+ */
+function poetheme_get_breadcrumbs_items() {
+    $options = poetheme_get_options();
+
+    if ( ! $options['enable_breadcrumbs'] ) {
+        return array();
+    }
+
+    $items   = array();
+    $items[] = array(
+        'label' => __( 'Home', 'poetheme' ),
+        'url'   => home_url( '/' ),
+    );
+
+    if ( is_front_page() ) {
+        return array();
+    }
+
+    if ( is_home() ) {
+        $posts_page_id = (int) get_option( 'page_for_posts' );
+        if ( $posts_page_id ) {
+            $items[] = array(
+                'label' => get_the_title( $posts_page_id ),
+                'url'   => get_permalink( $posts_page_id ),
+            );
+        }
+
+        return $items;
+    }
+
+    if ( is_singular() ) {
+        $post = get_queried_object();
+
+        if ( $post instanceof WP_Post ) {
+            $ancestors = array_reverse( get_post_ancestors( $post ) );
+
+            foreach ( $ancestors as $ancestor_id ) {
+                $items[] = array(
+                    'label' => get_the_title( $ancestor_id ),
+                    'url'   => get_permalink( $ancestor_id ),
+                );
+            }
+
+            $items[] = array(
+                'label' => get_the_title( $post ),
+                'url'   => get_permalink( $post ),
+            );
+        }
+    } elseif ( is_category() || is_tag() || is_tax() ) {
+        $term = get_queried_object();
+        if ( $term instanceof WP_Term ) {
+            if ( $term->parent ) {
+                $ancestors = array_reverse( get_ancestors( $term->term_id, $term->taxonomy ) );
+                foreach ( $ancestors as $ancestor_id ) {
+                    $ancestor = get_term( $ancestor_id, $term->taxonomy );
+                    if ( $ancestor && ! is_wp_error( $ancestor ) ) {
+                        $ancestor_link = get_term_link( $ancestor );
+                        if ( ! is_wp_error( $ancestor_link ) ) {
+                            $items[] = array(
+                                'label' => $ancestor->name,
+                                'url'   => $ancestor_link,
+                            );
+                        }
+                    }
+                }
+            }
+
+            $term_link = get_term_link( $term );
+
+            if ( ! is_wp_error( $term_link ) ) {
+                $items[] = array(
+                    'label' => $term->name,
+                    'url'   => $term_link,
+                );
+            }
+        }
+    } elseif ( is_post_type_archive() ) {
+        $post_type = get_post_type();
+        if ( $post_type ) {
+            $items[] = array(
+                'label' => post_type_archive_title( '', false ),
+                'url'   => get_post_type_archive_link( $post_type ),
+            );
+        }
+    } elseif ( is_search() ) {
+        $items[] = array(
+            'label' => sprintf( __( 'Search results for "%s"', 'poetheme' ), get_search_query() ),
+            'url'   => '',
+        );
+    } elseif ( is_404() ) {
+        $items[] = array(
+            'label' => __( '404 Not Found', 'poetheme' ),
+            'url'   => '',
+        );
+    }
+
+    return $items;
+}
+
+/**
+ * Output breadcrumbs markup.
+ */
+function poetheme_the_breadcrumbs() {
+    $items = poetheme_get_breadcrumbs_items();
+
+    if ( empty( $items ) ) {
+        return;
+    }
+    ?>
+    <nav class="breadcrumbs" aria-label="<?php esc_attr_e( 'Breadcrumb', 'poetheme' ); ?>">
+        <ol class="flex space-x-2" itemscope itemtype="https://schema.org/BreadcrumbList">
+            <?php foreach ( $items as $index => $item ) : ?>
+                <li class="flex items-center" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+                    <?php if ( ! empty( $item['url'] ) ) : ?>
+                        <a href="<?php echo esc_url( $item['url'] ); ?>" itemprop="item">
+                            <span itemprop="name"><?php echo esc_html( $item['label'] ); ?></span>
+                        </a>
+                    <?php else : ?>
+                        <span itemprop="name"><?php echo esc_html( $item['label'] ); ?></span>
+                    <?php endif; ?>
+                    <meta itemprop="position" content="<?php echo esc_attr( $index + 1 ); ?>" />
+                    <?php if ( $index < count( $items ) - 1 ) : ?>
+                        <span class="mx-2" aria-hidden="true">/</span>
+                    <?php endif; ?>
+                </li>
+            <?php endforeach; ?>
+        </ol>
+    </nav>
+    <?php
+}
+
+/**
+ * Output site logo.
+ */
+function poetheme_the_logo() {
+    $options = poetheme_get_options();
+
+    if ( has_custom_logo() ) {
+        the_custom_logo();
+        return;
+    }
+
+    if ( ! empty( $options['custom_logo'] ) ) {
+        $alt = esc_attr( get_bloginfo( 'name' ) );
+        echo '<a href="' . esc_url( home_url( '/' ) ) . '" class="inline-flex" rel="home">';
+        echo '<img src="' . esc_url( $options['custom_logo'] ) . '" alt="' . $alt . '" class="h-12 w-auto" />';
+        echo '</a>';
+        return;
+    }
+
+    echo '<a href="' . esc_url( home_url( '/' ) ) . '" class="text-2xl font-bold" rel="home">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
+}
+
+/**
+ * Output accessible pagination.
+ */
+function poetheme_the_posts_navigation() {
+    the_posts_pagination(
+        array(
+            'mid_size'           => 2,
+            'prev_text'          => __( 'Previous', 'poetheme' ),
+            'next_text'          => __( 'Next', 'poetheme' ),
+            'screen_reader_text' => __( 'Posts navigation', 'poetheme' ),
+        )
+    );
+}

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Theme options page.
+ *
+ * @package PoeTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register theme settings.
+ */
+function poetheme_register_settings() {
+    register_setting( 'poetheme_options', 'poetheme_options', 'poetheme_sanitize_options' );
+
+    add_settings_section(
+        'poetheme_general_section',
+        __( 'General', 'poetheme' ),
+        '__return_false',
+        'poetheme_options'
+    );
+
+    add_settings_field(
+        'poetheme_tagline',
+        __( 'Alternative Tagline', 'poetheme' ),
+        'poetheme_field_tagline',
+        'poetheme_options',
+        'poetheme_general_section'
+    );
+
+    add_settings_field(
+        'poetheme_enable_breadcrumbs',
+        __( 'Enable Breadcrumbs', 'poetheme' ),
+        'poetheme_field_enable_breadcrumbs',
+        'poetheme_options',
+        'poetheme_general_section'
+    );
+
+    add_settings_section(
+        'poetheme_logo_section',
+        __( 'Logo', 'poetheme' ),
+        '__return_false',
+        'poetheme_options'
+    );
+
+    add_settings_field(
+        'poetheme_custom_logo',
+        __( 'Custom Logo URL', 'poetheme' ),
+        'poetheme_field_custom_logo',
+        'poetheme_options',
+        'poetheme_logo_section'
+    );
+}
+add_action( 'admin_init', 'poetheme_register_settings' );
+
+/**
+ * Add options page to admin menu.
+ */
+function poetheme_add_options_page() {
+    add_theme_page(
+        __( 'PoeTheme Options', 'poetheme' ),
+        __( 'PoeTheme Options', 'poetheme' ),
+        'manage_options',
+        'poetheme-options',
+        'poetheme_render_options_page'
+    );
+}
+add_action( 'admin_menu', 'poetheme_add_options_page' );
+
+/**
+ * Sanitize options.
+ *
+ * @param array $input Input values.
+ * @return array
+ */
+function poetheme_sanitize_options( $input ) {
+    $output = poetheme_get_options();
+
+    if ( isset( $input['tagline'] ) ) {
+        $output['tagline'] = sanitize_text_field( $input['tagline'] );
+    }
+
+    $output['enable_breadcrumbs'] = isset( $input['enable_breadcrumbs'] ) ? (bool) $input['enable_breadcrumbs'] : false;
+
+    if ( isset( $input['custom_logo'] ) ) {
+        $output['custom_logo'] = esc_url_raw( $input['custom_logo'] );
+    }
+
+    return $output;
+}
+
+/**
+ * Retrieve theme options with defaults.
+ *
+ * @return array
+ */
+function poetheme_get_options() {
+    $defaults = array(
+        'tagline'            => '',
+        'enable_breadcrumbs' => true,
+        'custom_logo'        => '',
+    );
+
+    $options = get_option( 'poetheme_options', array() );
+
+    return wp_parse_args( $options, $defaults );
+}
+
+/**
+ * Render tagline field.
+ */
+function poetheme_field_tagline() {
+    $options = poetheme_get_options();
+    ?>
+    <input type="text" id="poetheme_tagline" name="poetheme_options[tagline]" value="<?php echo esc_attr( $options['tagline'] ); ?>" class="regular-text" />
+    <p class="description"><?php esc_html_e( 'Overrides the site tagline for meta descriptions.', 'poetheme' ); ?></p>
+    <?php
+}
+
+/**
+ * Render breadcrumbs toggle field.
+ */
+function poetheme_field_enable_breadcrumbs() {
+    $options = poetheme_get_options();
+    ?>
+    <label for="poetheme_enable_breadcrumbs">
+        <input type="checkbox" id="poetheme_enable_breadcrumbs" name="poetheme_options[enable_breadcrumbs]" value="1" <?php checked( $options['enable_breadcrumbs'], true ); ?> />
+        <?php esc_html_e( 'Display breadcrumbs on archive and singular pages.', 'poetheme' ); ?>
+    </label>
+    <?php
+}
+
+/**
+ * Render custom logo field.
+ */
+function poetheme_field_custom_logo() {
+    $options = poetheme_get_options();
+    ?>
+    <input type="url" id="poetheme_custom_logo" name="poetheme_options[custom_logo]" value="<?php echo esc_attr( $options['custom_logo'] ); ?>" class="regular-text" />
+    <p class="description"><?php esc_html_e( 'Paste the URL of the logo image if you prefer not to use the Customizer logo.', 'poetheme' ); ?></p>
+    <?php
+}
+
+/**
+ * Render options page markup.
+ */
+function poetheme_render_options_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'PoeTheme Options', 'poetheme' ); ?></h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields( 'poetheme_options' );
+            do_settings_sections( 'poetheme_options' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Main template file.
+ *
+ * @package PoeTheme
+ */
+
+get_header();
+?>
+<section class="grid gap-10 lg:grid-cols-[2fr,1fr]">
+    <div>
+        <?php if ( have_posts() ) : ?>
+            <?php while ( have_posts() ) : the_post(); ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 focus-within:ring-2 focus-within:ring-indigo-500' ); ?> itemscope itemtype="https://schema.org/Article">
+                    <header class="mb-4">
+                        <?php if ( is_singular() ) : ?>
+                            <h1 class="text-3xl font-bold mb-2" itemprop="headline"><?php the_title(); ?></h1>
+                        <?php else : ?>
+                            <h2 class="text-2xl font-semibold mb-2">
+                                <a class="text-gray-900 hover:text-indigo-600 focus:text-indigo-600" href="<?php the_permalink(); ?>" rel="bookmark" itemprop="url">
+                                    <span itemprop="headline"><?php the_title(); ?></span>
+                                </a>
+                            </h2>
+                        <?php endif; ?>
+                        <p class="text-sm text-gray-500">
+                            <time datetime="<?php echo esc_attr( get_the_date( DATE_W3C ) ); ?>" itemprop="datePublished"><?php echo esc_html( get_the_date() ); ?></time>
+                            <span class="mx-2" aria-hidden="true">•</span>
+                            <span itemprop="author" itemscope itemtype="https://schema.org/Person">
+                                <span class="screen-reader-text"><?php esc_html_e( 'Author', 'poetheme' ); ?> </span>
+                                <?php
+                                $author_id   = get_the_author_meta( 'ID' );
+                                $author_url  = get_author_posts_url( $author_id );
+                                $author_name = get_the_author();
+                                ?>
+                                <a class="hover:text-indigo-600 focus:text-indigo-600" href="<?php echo esc_url( $author_url ); ?>" rel="author" itemprop="name"><?php echo esc_html( $author_name ); ?></a>
+                            </span>
+                        </p>
+                    </header>
+
+                    <div class="space-y-4 leading-relaxed" itemprop="articleBody">
+                        <?php
+                        if ( is_singular() ) {
+                            the_content();
+                            wp_link_pages(
+                                array(
+                                    'before' => '<nav class="page-links" aria-label="' . esc_attr__( 'Page', 'poetheme' ) . '">',
+                                    'after'  => '</nav>',
+                                )
+                            );
+                        } else {
+                            the_excerpt();
+                        }
+                        ?>
+                    </div>
+
+                    <?php if ( is_singular() ) : ?>
+                        <footer class="mt-6 text-sm text-gray-500 space-y-2">
+                            <?php
+                            $tags_list = get_the_tag_list( '', ', ' );
+                            if ( $tags_list ) {
+                                echo '<p>' . esc_html__( 'Tags: ', 'poetheme' ) . wp_kses_post( $tags_list ) . '</p>';
+                            }
+
+                            $categories_list = get_the_category_list( ', ' );
+                            if ( $categories_list ) {
+                                echo '<p>' . esc_html__( 'Categories: ', 'poetheme' ) . wp_kses_post( $categories_list ) . '</p>';
+                            }
+                            ?>
+                        </footer>
+                        <?php comments_template(); ?>
+                    <?php endif; ?>
+                </article>
+            <?php endwhile; ?>
+
+            <div class="mt-8">
+                <?php
+                if ( is_singular() ) {
+                    the_post_navigation(
+                        array(
+                            'prev_text' => '<span class="screen-reader-text">' . esc_html__( 'Previous', 'poetheme' ) . '</span> %title',
+                            'next_text' => '<span class="screen-reader-text">' . esc_html__( 'Next', 'poetheme' ) . '</span> %title',
+                        )
+                    );
+                } else {
+                    poetheme_the_posts_navigation();
+                }
+                ?>
+            </div>
+        <?php else : ?>
+            <article class="bg-white rounded-lg shadow-sm p-6">
+                <header class="mb-4">
+                    <h2 class="text-2xl font-semibold"><?php esc_html_e( 'Nothing found', 'poetheme' ); ?></h2>
+                </header>
+                <p><?php esc_html_e( 'It seems we can’t find what you’re looking for. Perhaps searching can help.', 'poetheme' ); ?></p>
+                <?php get_search_form(); ?>
+            </article>
+        <?php endif; ?>
+    </div>
+
+    <aside class="lg:sticky lg:top-8 space-y-6" aria-label="<?php esc_attr_e( 'Sidebar', 'poetheme' ); ?>">
+        <?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+            <?php dynamic_sidebar( 'sidebar-1' ); ?>
+        <?php else : ?>
+            <section class="bg-white rounded-lg shadow-sm p-6">
+                <h2 class="text-xl font-semibold mb-3"><?php esc_html_e( 'About this site', 'poetheme' ); ?></h2>
+                <p class="text-sm text-gray-600"><?php esc_html_e( 'Use the Widgets area in the WordPress admin to customize this sidebar.', 'poetheme' ); ?></p>
+            </section>
+        <?php endif; ?>
+    </aside>
+</section>
+<?php
+get_footer();

--- a/languages/poetheme.pot
+++ b/languages/poetheme.pot
@@ -1,0 +1,188 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PoeTheme 1.0.0\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: OpenAI ChatGPT\n"
+
+#: comments.php:24
+msgid "%1$s Comment"
+msgstr ""
+
+#: comments.php:24
+msgid "%1$s Comments"
+msgstr ""
+
+#: comments.php:39
+msgid "Comments navigation"
+msgstr ""
+
+#: comments.php:42
+msgid "Older Comments"
+msgstr ""
+
+#: comments.php:43
+msgid "Newer Comments"
+msgstr ""
+
+#: comments.php:50
+msgid "Comments are closed."
+msgstr ""
+
+#: footer.php:20
+msgid "Footer widgets"
+msgstr ""
+
+#: footer.php:26
+msgid "Widget Area"
+msgstr ""
+
+#: footer.php:27
+msgid "Add widgets in the WordPress admin to replace this placeholder."
+msgstr ""
+
+#: index.php:88
+msgid "About this site"
+msgstr ""
+
+#: index.php:89
+msgid "Use the Widgets area in the WordPress admin to customize this sidebar."
+msgstr ""
+
+#: footer.php:33
+msgid "Footer navigation"
+msgstr ""
+
+#: header.php:27
+msgid "Primary navigation"
+msgstr ""
+
+#: functions.php:34
+msgid "Primary Menu"
+msgstr ""
+
+#: functions.php:35
+msgid "Footer Menu"
+msgstr ""
+
+#: functions.php:64
+msgid "Sidebar"
+msgstr ""
+
+#: functions.php:66
+msgid "Add widgets here."
+msgstr ""
+
+#: functions.php:76
+msgid "Footer Widgets"
+msgstr ""
+
+#: functions.php:78
+msgid "Appears in the footer widget area."
+msgstr ""
+
+#: functions.php:113
+msgid "Skip to content"
+msgstr ""
+
+#: inc/template-tags.php:27
+msgid "Home"
+msgstr ""
+
+#: inc/template-tags.php:63
+msgid "Search results for \"%s\""
+msgstr ""
+
+#: inc/template-tags.php:69
+msgid "404 Not Found"
+msgstr ""
+
+#: inc/template-tags.php:83
+msgid "Breadcrumb"
+msgstr ""
+
+#: inc/template-tags.php:120
+msgid "Previous"
+msgstr ""
+
+#: inc/template-tags.php:121
+msgid "Next"
+msgstr ""
+
+#: inc/template-tags.php:122
+msgid "Posts navigation"
+msgstr ""
+
+#: inc/theme-options.php:20
+msgid "General"
+msgstr ""
+
+#: inc/theme-options.php:28
+msgid "Alternative Tagline"
+msgstr ""
+
+#: inc/theme-options.php:37
+msgid "Enable Breadcrumbs"
+msgstr ""
+
+#: inc/theme-options.php:48
+msgid "Logo"
+msgstr ""
+
+#: inc/theme-options.php:56
+msgid "Custom Logo URL"
+msgstr ""
+
+#: inc/theme-options.php:90
+msgid "Overrides the site tagline for meta descriptions."
+msgstr ""
+
+#: inc/theme-options.php:101
+msgid "Display breadcrumbs on archive and singular pages."
+msgstr ""
+
+#: inc/theme-options.php:112
+msgid "Paste the URL of the logo image if you prefer not to use the Customizer logo."
+msgstr ""
+
+#: inc/theme-options.php:122
+msgid "PoeTheme Options"
+msgstr ""
+
+#: index.php:24
+msgid "Author"
+msgstr ""
+
+#: index.php:43
+msgid "Page"
+msgstr ""
+
+#: index.php:53
+msgid "Tags: "
+msgstr ""
+
+#: index.php:54
+msgid "Categories: "
+msgstr ""
+
+#: index.php:66
+msgid "Nothing found"
+msgstr ""
+
+#: index.php:69
+msgid "It seems we can’t find what you’re looking for. Perhaps searching can help."
+msgstr ""
+
+#: searchform.php:11
+msgid "Search for:"
+msgstr ""
+
+#: searchform.php:12
+msgid "Search …"
+msgstr ""
+
+#: searchform.php:14
+msgid "Search"
+msgstr ""

--- a/rtl.css
+++ b/rtl.css
@@ -1,0 +1,15 @@
+/* RTL adjustments for PoeTheme */
+body {
+  direction: rtl;
+}
+
+.nav-primary,
+.breadcrumbs,
+.widget,
+footer nav {
+  text-align: right;
+}
+
+.breadcrumbs .mx-2 {
+  transform: scaleX(-1);
+}

--- a/searchform.php
+++ b/searchform.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Search form template.
+ *
+ * @package PoeTheme
+ */
+?>
+<form role="search" method="get" class="search-form flex items-center gap-2" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+    <label class="screen-reader-text" for="search-field"><?php esc_html_e( 'Search for:', 'poetheme' ); ?></label>
+    <input type="search" id="search-field" class="flex-1 border border-gray-300 rounded-md px-3 py-2 focus:border-indigo-500 focus:ring focus:ring-indigo-200" placeholder="<?php esc_attr_e( 'Search …', 'poetheme' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s" />
+    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-4 focus:ring-indigo-300">
+        <?php esc_html_e( 'Search', 'poetheme' ); ?>
+    </button>
+</form>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,113 @@
+/*
+Theme Name: PoeTheme
+Theme URI: https://example.com/poetheme
+Author: Cosè Murciano
+Author URI: https://example.com
+Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: poetheme
+Tags: blog, accessibility-ready, custom-logo, custom-menu, rtl-language-support, translation-ready
+*/
+
+/* Tailwind CSS is loaded via CDN. Use this file for additional custom styles and accessibility enhancements. */
+
+:root {
+  --poetheme-focus-color: #1e40af;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #111827;
+  color: #f9fafb;
+  padding: 0.75rem 1rem;
+  z-index: 100;
+  transition: top 0.2s ease-in-out;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--poetheme-focus-color);
+}
+
+a:focus,
+button:focus,
+input:focus,
+textarea:focus {
+  outline: 3px solid var(--poetheme-focus-color);
+  outline-offset: 2px;
+}
+
+.nav-primary a:focus {
+  outline: 3px solid var(--poetheme-focus-color);
+}
+
+.screen-reader-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.screen-reader-text:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  padding: 1rem;
+  clip: auto;
+  background: #111827;
+  color: #f9fafb;
+}
+
+.breadcrumbs {
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+.breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumbs a:hover,
+.breadcrumbs a:focus {
+  text-decoration: underline;
+}
+
+article {
+  margin-bottom: 3rem;
+}
+
+article header h1,
+article header h2 {
+  font-size: 1.875rem;
+  font-weight: 700;
+}
+
+.wp-block-image img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* RTL support */
+body.rtl {
+  direction: rtl;
+  text-align: right;
+}
+
+body.rtl .breadcrumbs {
+  direction: rtl;
+}
+
+body.rtl .skip-link {
+  left: auto;
+  right: 0;
+}


### PR DESCRIPTION
## Summary
- create the PoeTheme WordPress theme with Tailwind CSS, Alpine.js, and Lucide integrations plus RTL-ready styling
- implement Gutenberg block editor support, structured data breadcrumbs, accessibility enhancements, and widget areas
- add translatable strings, POT file, and admin options page for branding and breadcrumb controls

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68df97fa9ad48332913a587f4686f553