### PR TITLE
Add configurable responsive header layouts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,6 +33,7 @@ if ( ! function_exists( 'poetheme_setup' ) ) {
         register_nav_menus(
             array(
                 'primary' => __( 'Primary Menu', 'poetheme' ),
+                'top-info' => __( 'Top Info Menu', 'poetheme' ),
                 'footer'  => __( 'Footer Menu', 'poetheme' ),
             )
         );

--- a/header.php
+++ b/header.php
@@ -21,26 +21,17 @@
 <body <?php body_class( 'bg-gray-50 text-gray-900 leading-relaxed' ); ?>>
 <?php wp_body_open(); ?>
 <?php do_action( 'poetheme_before_header' ); ?>
-<header class="bg-white shadow-sm" role="banner">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div class="flex items-center gap-4">
-            <?php poetheme_the_logo(); ?>
-            <p class="text-sm text-gray-600" id="site-description"><?php echo esc_html( get_bloginfo( 'description' ) ); ?></p>
-        </div>
-        <nav class="nav-primary" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
-            <?php
-            wp_nav_menu(
-                array(
-                    'theme_location' => 'primary',
-                    'menu_class'     => 'flex flex-wrap gap-4 text-base font-medium',
-                    'container'      => false,
-                    'fallback_cb'    => 'wp_page_menu',
-                )
-            );
-            ?>
-        </nav>
-    </div>
-</header>
+<?php
+$header_context = poetheme_get_header_context();
+$layout         = isset( $header_context['layout'] ) ? $header_context['layout'] : 'style-1';
+$template_slug  = 'template-parts/header/' . $layout;
+
+if ( ! locate_template( array( $template_slug . '.php' ), false, false ) ) {
+    $template_slug = 'template-parts/header/style-1';
+}
+
+get_template_part( $template_slug, null, $header_context );
+?>
 
 <main id="primary-content" class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10" tabindex="-1">
     <?php poetheme_the_breadcrumbs(); ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -188,6 +188,47 @@ function poetheme_the_logo() {
 }
 
 /**
+ * Build the context array used by header templates.
+ *
+ * @return array
+ */
+function poetheme_get_header_context() {
+    $options = poetheme_get_header_options();
+
+    $top_bar_texts = array();
+    if ( isset( $options['top_bar_texts'] ) && is_array( $options['top_bar_texts'] ) ) {
+        foreach ( $options['top_bar_texts'] as $text ) {
+            $top_bar_texts[] = sanitize_text_field( $text );
+        }
+    }
+    $top_bar_texts = array_pad( array_slice( $top_bar_texts, 0, 3 ), 3, '' );
+
+    $cta_text = isset( $options['cta_text'] ) ? sanitize_text_field( $options['cta_text'] ) : '';
+    $cta_url  = '';
+    if ( ! empty( $options['cta_url'] ) ) {
+        $cta_url = $options['cta_url'];
+    } elseif ( ! empty( $cta_text ) ) {
+        $cta_url = home_url( '/' );
+    }
+
+    $social_links = array();
+    $socials      = poetheme_get_header_social_networks();
+    foreach ( $socials as $key => $social ) {
+        $social_links[ $key ] = isset( $options['social_links'][ $key ] ) ? $options['social_links'][ $key ] : '';
+    }
+
+    return array(
+        'layout'             => isset( $options['layout'] ) ? $options['layout'] : 'style-1',
+        'show_top_bar'       => ! empty( $options['show_top_bar'] ),
+        'top_bar_texts'      => $top_bar_texts,
+        'cta_text'           => $cta_text,
+        'cta_url'            => $cta_url,
+        'social_links'       => $social_links,
+        'social_definitions' => $socials,
+    );
+}
+
+/**
  * Output accessible pagination.
  */
 function poetheme_the_posts_navigation() {

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -10,6 +10,58 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Retrieve the available header social networks definitions.
+ *
+ * @return array
+ */
+function poetheme_get_header_social_networks() {
+    return array(
+        'facebook'  => array(
+            'label' => __( 'Facebook', 'poetheme' ),
+            'icon'  => 'facebook',
+        ),
+        'instagram' => array(
+            'label' => __( 'Instagram', 'poetheme' ),
+            'icon'  => 'instagram',
+        ),
+        'youtube'   => array(
+            'label' => __( 'YouTube', 'poetheme' ),
+            'icon'  => 'youtube',
+        ),
+        'twitter'   => array(
+            'label' => __( 'Twitter', 'poetheme' ),
+            'icon'  => 'twitter',
+        ),
+        'linkedin'  => array(
+            'label' => __( 'LinkedIn', 'poetheme' ),
+            'icon'  => 'linkedin',
+        ),
+    );
+}
+
+/**
+ * Default values for header options.
+ *
+ * @return array
+ */
+function poetheme_get_default_header_options() {
+    $social_defaults = array();
+
+    foreach ( poetheme_get_header_social_networks() as $key => $data ) {
+        $social_defaults[ $key ] = '';
+    }
+
+    return array(
+        'layout'         => 'style-1',
+        'show_top_bar'   => true,
+        'top_bar_texts'  => array( '', '', '' ),
+        'cta_text'       => __( 'Get Started', 'poetheme' ),
+        'cta_url'        => home_url( '/' ),
+        'social_links'   => $social_defaults,
+    );
+}
+
+/**
  * Register theme settings.
  */
 function poetheme_register_settings() {
@@ -32,6 +84,16 @@ function poetheme_register_settings() {
             'type'              => 'string',
             'sanitize_callback' => 'poetheme_sanitize_custom_css',
             'default'           => '',
+        )
+    );
+
+    register_setting(
+        'poetheme_header_group',
+        'poetheme_header',
+        array(
+            'type'              => 'array',
+            'sanitize_callback' => 'poetheme_sanitize_header_options',
+            'default'           => poetheme_get_default_header_options(),
         )
     );
 }
@@ -162,10 +224,89 @@ function poetheme_render_logo_page() {
  * Render the header settings page.
  */
 function poetheme_render_header_page() {
+    $options       = poetheme_get_header_options();
+    $layouts       = array(
+        'style-1' => __( 'Layout 1 – Classico', 'poetheme' ),
+        'style-2' => __( 'Layout 2 – Centrato', 'poetheme' ),
+        'style-3' => __( 'Layout 3 – Minimal', 'poetheme' ),
+        'style-4' => __( 'Layout 4 – Vetrina', 'poetheme' ),
+        'style-5' => __( 'Layout 5 – Overlay', 'poetheme' ),
+        'style-6' => __( 'Layout 6 – Sticky', 'poetheme' ),
+        'style-7' => __( 'Layout 7 – Promo', 'poetheme' ),
+        'style-8' => __( 'Layout 8 – E-commerce', 'poetheme' ),
+    );
+    $socials       = poetheme_get_header_social_networks();
+    $top_bar_texts = isset( $options['top_bar_texts'] ) && is_array( $options['top_bar_texts'] ) ? $options['top_bar_texts'] : array();
+    $top_bar_texts = array_pad( array_slice( $top_bar_texts, 0, 3 ), 3, '' );
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Intestazione', 'poetheme' ); ?></h1>
-        <p class="description"><?php esc_html_e( "Le impostazioni dell'intestazione saranno disponibili a breve.", 'poetheme' ); ?></p>
+        <form action="options.php" method="post" class="poetheme-options-form">
+            <?php settings_fields( 'poetheme_header_group' ); ?>
+            <table class="form-table" role="presentation">
+                <tbody>
+                    <tr>
+                        <th scope="row"><label for="poetheme_header_layout"><?php esc_html_e( 'Seleziona layout', 'poetheme' ); ?></label></th>
+                        <td>
+                            <select id="poetheme_header_layout" name="poetheme_header[layout]">
+                                <?php foreach ( $layouts as $layout_key => $label ) : ?>
+                                    <option value="<?php echo esc_attr( $layout_key ); ?>" <?php selected( $options['layout'], $layout_key ); ?>><?php echo esc_html( $label ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <p class="description"><?php esc_html_e( "Scegli quale testata applicare al tema.", 'poetheme' ); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Barra superiore', 'poetheme' ); ?></th>
+                        <td>
+                            <label for="poetheme_header_show_top_bar">
+                                <input type="checkbox" id="poetheme_header_show_top_bar" name="poetheme_header[show_top_bar]" value="1" <?php checked( ! empty( $options['show_top_bar'] ) ); ?> />
+                                <?php esc_html_e( 'Mostra la barra superiore con informazioni e social.', 'poetheme' ); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e( 'La barra comprende tre campi di testo, un menù informativo e le icone social.', 'poetheme' ); ?></p>
+                        </td>
+                    </tr>
+                    <?php for ( $i = 0; $i < 3; $i++ ) : ?>
+                        <tr>
+                            <th scope="row">
+                                <label for="poetheme_header_top_text_<?php echo esc_attr( $i ); ?>"><?php printf( esc_html__( 'Testo barra %d', 'poetheme' ), $i + 1 ); ?></label>
+                            </th>
+                            <td>
+                                <input type="text" id="poetheme_header_top_text_<?php echo esc_attr( $i ); ?>" name="poetheme_header[top_bar_texts][<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $top_bar_texts[ $i ] ); ?>" class="regular-text" />
+                            </td>
+                        </tr>
+                    <?php endfor; ?>
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Call to Action', 'poetheme' ); ?></th>
+                        <td>
+                            <label for="poetheme_header_cta_text" class="screen-reader-text"><?php esc_html_e( 'Testo pulsante', 'poetheme' ); ?></label>
+                            <input type="text" id="poetheme_header_cta_text" name="poetheme_header[cta_text]" value="<?php echo esc_attr( $options['cta_text'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Get Started', 'poetheme' ); ?>" />
+                            <p class="description"><?php esc_html_e( 'Lascia vuoto per nascondere il pulsante.', 'poetheme' ); ?></p>
+                            <label for="poetheme_header_cta_url" class="screen-reader-text"><?php esc_html_e( 'Link pulsante', 'poetheme' ); ?></label>
+                            <input type="url" id="poetheme_header_cta_url" name="poetheme_header[cta_url]" value="<?php echo esc_attr( $options['cta_url'] ); ?>" class="regular-text" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Icone social', 'poetheme' ); ?></th>
+                        <td>
+                            <p class="description"><?php esc_html_e( 'Inserisci gli URL dei tuoi profili social per mostrarne le icone nella barra superiore.', 'poetheme' ); ?></p>
+                            <?php foreach ( $socials as $key => $social ) :
+                                $value = isset( $options['social_links'][ $key ] ) ? $options['social_links'][ $key ] : '';
+                                ?>
+                                <p>
+                                    <label for="poetheme_header_social_<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $social['label'] ); ?></label><br />
+                                    <input type="url" id="poetheme_header_social_<?php echo esc_attr( $key ); ?>" name="poetheme_header[social_links][<?php echo esc_attr( $key ); ?>]" value="<?php echo esc_attr( $value ); ?>" class="regular-text" placeholder="https://" />
+                                </p>
+                            <?php endforeach; ?>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+        <p class="description">
+            <?php esc_html_e( 'Suggerimento: assegna un menù alla posizione "Top Info Menu" da Aspetto → Menu per mostrare i link informativi nella barra superiore.', 'poetheme' ); ?>
+        </p>
     </div>
     <?php
 }
@@ -264,6 +405,49 @@ function poetheme_sanitize_custom_css( $css ) {
 }
 
 /**
+ * Sanitize header options.
+ *
+ * @param array $input Raw input values.
+ * @return array
+ */
+function poetheme_sanitize_header_options( $input ) {
+    $defaults = poetheme_get_default_header_options();
+    $output   = $defaults;
+
+    if ( ! is_array( $input ) ) {
+        return $output;
+    }
+
+    if ( isset( $input['layout'] ) ) {
+        $layout = sanitize_key( $input['layout'] );
+        if ( preg_match( '/^style-[1-8]$/', $layout ) ) {
+            $output['layout'] = $layout;
+        }
+    }
+
+    $output['show_top_bar'] = ! empty( $input['show_top_bar'] );
+
+    $output['top_bar_texts'] = array();
+    for ( $i = 0; $i < 3; $i++ ) {
+        $value = '';
+        if ( isset( $input['top_bar_texts'][ $i ] ) ) {
+            $value = sanitize_text_field( $input['top_bar_texts'][ $i ] );
+        }
+        $output['top_bar_texts'][ $i ] = $value;
+    }
+
+    $output['cta_text'] = isset( $input['cta_text'] ) ? sanitize_text_field( $input['cta_text'] ) : '';
+    $output['cta_url']  = isset( $input['cta_url'] ) ? esc_url_raw( $input['cta_url'] ) : '';
+
+    $output['social_links'] = array();
+    foreach ( poetheme_get_header_social_networks() as $key => $social ) {
+        $output['social_links'][ $key ] = isset( $input['social_links'][ $key ] ) ? esc_url_raw( $input['social_links'][ $key ] ) : '';
+    }
+
+    return $output;
+}
+
+/**
  * Enqueue admin assets for the options pages.
  *
  * @param string $hook Current admin page hook.
@@ -326,4 +510,41 @@ function poetheme_get_options() {
     $options = get_option( 'poetheme_options', array() );
 
     return wp_parse_args( $options, $defaults );
+}
+
+/**
+ * Retrieve header options with defaults.
+ *
+ * @return array
+ */
+function poetheme_get_header_options() {
+    $defaults = poetheme_get_default_header_options();
+    $options  = get_option( 'poetheme_header', array() );
+    $options  = wp_parse_args( $options, $defaults );
+
+    // Ensure top bar texts always contain three entries.
+    $top_bar_texts = array();
+    if ( isset( $options['top_bar_texts'] ) && is_array( $options['top_bar_texts'] ) ) {
+        $top_bar_texts = array_values( $options['top_bar_texts'] );
+    }
+    $options['top_bar_texts'] = array_pad( array_slice( $top_bar_texts, 0, 3 ), 3, '' );
+
+    // Merge social defaults preserving keys.
+    $social_defaults = $defaults['social_links'];
+    $social_values   = array();
+    if ( isset( $options['social_links'] ) && is_array( $options['social_links'] ) ) {
+        $social_values = $options['social_links'];
+    }
+    $options['social_links'] = array_merge( $social_defaults, array_intersect_key( $social_values, $social_defaults ) );
+
+    // Validate layout fallback.
+    $layout = isset( $options['layout'] ) ? sanitize_key( $options['layout'] ) : $defaults['layout'];
+    if ( ! preg_match( '/^style-[1-8]$/', $layout ) ) {
+        $layout = $defaults['layout'];
+    }
+    $options['layout'] = $layout;
+
+    $options['show_top_bar'] = ! empty( $options['show_top_bar'] );
+
+    return $options;
 }

--- a/template-parts/header/style-1.php
+++ b/template-parts/header/style-1.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Header layout: Style 1 (Classic).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-white shadow-sm" role="banner" x-data="{ mobileOpen: false }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-gray-900 text-white text-sm">
+            <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-6 gap-y-1">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span class="text-gray-200"><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav class="text-gray-300" aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-gray-300">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-blue-400 transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="border-b border-gray-200">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div class="flex items-center justify-between w-full md:w-auto gap-4">
+                    <?php poetheme_the_logo(); ?>
+                    <button type="button" class="md:hidden text-gray-700" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                        <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                        <i data-lucide="menu" class="w-6 h-6"></i>
+                    </button>
+                </div>
+
+                <nav class="nav-primary hidden md:flex flex-1 items-center justify-center gap-6 text-sm font-medium text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex flex-wrap items-center gap-6 text-sm font-medium',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <?php if ( '' !== $cta_text ) : ?>
+                    <div class="hidden md:block">
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-5 py-2 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden border-t border-gray-200 bg-white" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-4 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-3 text-base font-medium text-gray-800',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-2.php
+++ b/template-parts/header/style-2.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Header layout: Style 2 (Centered).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-white shadow-md" role="banner" x-data="{ mobileOpen: false }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-blue-600 text-white text-sm">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-6 gap-y-1">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span class="text-blue-50"><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav class="text-blue-100" aria-label="<?php esc_attr_e( 'Link rapidi', 'poetheme' ); ?>">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-blue-100">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-white transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="border-b border-blue-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
+            <div class="grid grid-cols-1 gap-6 md:grid-cols-[auto_1fr_auto] md:items-center">
+                <div class="flex items-center justify-between md:justify-start gap-4">
+                    <?php poetheme_the_logo(); ?>
+                    <button type="button" class="md:hidden text-blue-700" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                        <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                        <i data-lucide="menu" class="w-6 h-6"></i>
+                    </button>
+                </div>
+
+                <nav class="nav-primary hidden md:flex items-center justify-center gap-8 text-base font-semibold text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex items-center gap-8 text-base font-semibold tracking-tight',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <?php if ( '' !== $cta_text ) : ?>
+                    <div class="hidden md:flex justify-end">
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-5 py-2 rounded-full bg-blue-600 text-white shadow hover:bg-blue-700 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden border-t border-blue-100 bg-white" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-semibold text-gray-800',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-full bg-blue-600 text-white shadow hover:bg-blue-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-3.php
+++ b/template-parts/header/style-3.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Header layout: Style 3 (Minimal).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-white border-b border-gray-200" role="banner" x-data="{ mobileOpen: false }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-gray-50 text-xs text-gray-600 border-b border-gray-200">
+            <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-5 gap-y-1 tracking-widest uppercase">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav aria-label="<?php esc_attr_e( 'Link info', 'poetheme' ); ?>" class="uppercase tracking-[0.2em] text-gray-500">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-xs',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-gray-500">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-gray-900 transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-3 h-3"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-8">
+                <button type="button" class="md:hidden text-gray-800" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                    <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                    <i data-lucide="menu" class="w-6 h-6"></i>
+                </button>
+                <?php poetheme_the_logo(); ?>
+            </div>
+
+            <nav class="nav-primary hidden md:flex items-center gap-10 text-xs font-semibold tracking-[0.35em] text-gray-700 uppercase" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex items-center gap-10 text-xs font-semibold tracking-[0.35em] uppercase',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <div class="hidden md:block">
+                    <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-4 py-2 border border-gray-900 text-gray-900 uppercase tracking-[0.3em] text-[11px] hover:bg-gray-900 hover:text-white transition">
+                        <?php echo esc_html( $cta_text ); ?>
+                    </a>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden border-t border-gray-200 bg-white" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-4 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-3 text-sm font-medium text-gray-800 uppercase tracking-[0.2em]',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 border border-gray-900 text-gray-900 uppercase tracking-[0.3em] hover:bg-gray-900 hover:text-white transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-4.php
+++ b/template-parts/header/style-4.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Header layout: Style 4 (Showcase).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white" role="banner" x-data="{ mobileOpen: false }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-black bg-opacity-20 text-sm">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-indigo-100">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav aria-label="<?php esc_attr_e( 'Link utili', 'poetheme' ); ?>" class="text-indigo-100">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-indigo-100">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-white transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="backdrop-blur-sm bg-white/5">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
+            <div class="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="flex items-center justify-between w-full lg:w-auto gap-4">
+                    <?php poetheme_the_logo(); ?>
+                    <button type="button" class="lg:hidden text-white" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                        <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                        <i data-lucide="menu" class="w-6 h-6"></i>
+                    </button>
+                </div>
+
+                <nav class="nav-primary hidden lg:flex flex-1 items-center justify-center gap-8 text-sm font-medium" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex flex-wrap items-center gap-8 text-sm font-medium uppercase tracking-wide',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <?php if ( '' !== $cta_text ) : ?>
+                    <div class="hidden lg:block">
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-6 py-3 rounded-xl bg-white text-indigo-700 font-semibold shadow-lg shadow-indigo-900/30 hover:bg-indigo-50 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="lg:hidden bg-white text-gray-900" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-xl bg-indigo-600 text-white shadow hover:bg-indigo-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-5.php
+++ b/template-parts/header/style-5.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Header layout: Style 5 (Overlay).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative text-white" role="banner" x-data="{ mobileOpen: false }">
+    <div class="absolute inset-0 bg-gradient-to-r from-indigo-700 via-purple-600 to-blue-500"></div>
+    <div class="absolute inset-0 opacity-30 bg-cover bg-center" style="background-image: linear-gradient(135deg, rgba(255,255,255,0.1) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, transparent 75%, transparent);"></div>
+
+    <div class="relative">
+        <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+            <div class="bg-black bg-opacity-40 text-sm">
+                <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <?php if ( $has_top_texts ) : ?>
+                        <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-indigo-100">
+                            <?php foreach ( $top_bar_texts as $text ) : ?>
+                                <?php if ( '' === $text ) : continue; endif; ?>
+                                <span><?php echo esc_html( $text ); ?></span>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                        <?php if ( $has_top_menu ) : ?>
+                            <nav aria-label="<?php esc_attr_e( 'Link rapidi', 'poetheme' ); ?>" class="text-indigo-100">
+                                <?php
+                                wp_nav_menu(
+                                    array(
+                                        'theme_location' => 'top-info',
+                                        'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
+                                        'container'      => false,
+                                        'depth'          => 1,
+                                        'fallback_cb'    => false,
+                                    )
+                                );
+                                ?>
+                            </nav>
+                        <?php endif; ?>
+
+                        <?php if ( $has_social ) : ?>
+                            <div class="flex items-center gap-3 text-indigo-100">
+                                <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                    $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                    if ( empty( $url ) ) {
+                                        continue;
+                                    }
+                                    ?>
+                                    <a class="hover:text-white transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                        <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                        <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                    </a>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <div class="flex items-center justify-between">
+                <div class="flex items-center gap-4">
+                    <?php poetheme_the_logo(); ?>
+                    <p class="hidden md:block text-sm text-indigo-100"><?php echo esc_html( get_bloginfo( 'description' ) ); ?></p>
+                </div>
+
+                <button type="button" class="lg:hidden text-white" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                    <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                    <i data-lucide="menu" class="w-6 h-6"></i>
+                </button>
+
+                <nav class="nav-primary hidden lg:flex items-center gap-10 text-base font-medium" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex items-center gap-10 text-base font-medium uppercase tracking-wide',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <?php if ( '' !== $cta_text ) : ?>
+                    <div class="hidden lg:block">
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-6 py-3 rounded-full bg-white text-indigo-700 font-semibold shadow-lg shadow-indigo-900/30 hover:bg-indigo-50 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <div class="mt-10 grid gap-6 lg:grid-cols-2 lg:items-center">
+                <div class="space-y-4">
+                    <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight">
+                        <?php echo esc_html( get_bloginfo( 'name' ) ); ?>
+                    </h1>
+                    <p class="text-indigo-100 text-lg max-w-xl">
+                        <?php echo esc_html__( 'Un header con effetto overlay perfetto per presentazioni immersive.', 'poetheme' ); ?>
+                    </p>
+                    <?php if ( '' !== $cta_text ) : ?>
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-6 py-3 rounded-full bg-white text-indigo-700 font-semibold shadow-lg shadow-indigo-900/30 hover:bg-indigo-50 transition lg:hidden">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    <?php endif; ?>
+                </div>
+                <div class="hidden lg:flex justify-end">
+                    <div class="bg-white/10 rounded-2xl p-6 backdrop-blur">
+                        <p class="text-sm uppercase tracking-wide text-indigo-100 mb-2"><?php esc_html_e( 'Punti di forza', 'poetheme' ); ?></p>
+                        <ul class="space-y-2 text-indigo-50 text-sm">
+                            <li class="flex items-center gap-2"><i data-lucide="sparkles" class="w-4 h-4"></i><span><?php esc_html_e( 'Design d\'impatto', 'poetheme' ); ?></span></li>
+                            <li class="flex items-center gap-2"><i data-lucide="clock" class="w-4 h-4"></i><span><?php esc_html_e( 'Navigazione rapida', 'poetheme' ); ?></span></li>
+                            <li class="flex items-center gap-2"><i data-lucide="shield" class="w-4 h-4"></i><span><?php esc_html_e( 'Massima affidabilità', 'poetheme' ); ?></span></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="lg:hidden bg-white text-gray-900" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-full bg-indigo-600 text-white shadow hover:bg-indigo-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-6.php
+++ b/template-parts/header/style-6.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Header layout: Style 6 (Sticky).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="sticky top-0 z-40" role="banner" x-data="{ mobileOpen: false, scrolled: false }" @scroll.window="scrolled = window.scrollY > 30">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-rose-600 text-white text-xs" x-show="!scrolled" x-transition.opacity>
+            <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span class="uppercase tracking-wide text-rose-100"><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-5 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav aria-label="<?php esc_attr_e( 'Informazioni', 'poetheme' ); ?>" class="text-rose-100">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-rose-100">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-white transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-3.5 h-3.5"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="bg-white border-b border-rose-100 transition-all duration-200" :class="{ 'shadow-lg backdrop-blur bg-white/95': scrolled }">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between py-5 md:py-6">
+                <div class="flex items-center gap-4">
+                    <button type="button" class="md:hidden text-rose-600" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                        <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                        <i data-lucide="menu" class="w-6 h-6"></i>
+                    </button>
+                    <?php poetheme_the_logo(); ?>
+                </div>
+
+                <nav class="nav-primary hidden md:flex items-center gap-8 text-sm font-semibold text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex items-center gap-8 text-sm font-semibold uppercase tracking-wide',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <?php if ( '' !== $cta_text ) : ?>
+                    <div class="hidden md:block">
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-5 py-2.5 rounded-lg bg-rose-600 text-white font-semibold shadow hover:bg-rose-700 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden bg-white border-b border-rose-100" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-800',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-lg bg-rose-600 text-white font-semibold shadow hover:bg-rose-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-7.php
+++ b/template-parts/header/style-7.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Header layout: Style 7 (Promo).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-white shadow-sm" role="banner" x-data="{ mobileOpen: false, promoOpen: true }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-gray-900 text-white text-xs">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-5 gap-y-1 text-gray-200">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav aria-label="<?php esc_attr_e( 'Menu informazioni', 'poetheme' ); ?>" class="text-gray-300">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-gray-300">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-orange-400 transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div x-show="promoOpen" x-transition.opacity class="bg-gradient-to-r from-orange-500 via-amber-500 to-yellow-500 text-white text-sm">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between">
+            <div class="flex items-center gap-2 font-semibold">
+                <i data-lucide="sparkles" class="w-4 h-4"></i>
+                <span><?php esc_html_e( 'Spedizione gratuita oltre 50€ per un tempo limitato!', 'poetheme' ); ?></span>
+            </div>
+            <button type="button" class="text-white/80 hover:text-white" @click="promoOpen = false">
+                <span class="sr-only"><?php esc_html_e( 'Nascondi promozione', 'poetheme' ); ?></span>
+                <i data-lucide="x" class="w-4 h-4"></i>
+            </button>
+        </div>
+    </div>
+
+    <div class="border-b border-gray-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div class="flex items-center justify-between gap-6">
+                <div class="flex items-center gap-4">
+                    <button type="button" class="md:hidden text-gray-700" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                        <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                        <i data-lucide="menu" class="w-6 h-6"></i>
+                    </button>
+                    <?php poetheme_the_logo(); ?>
+                </div>
+
+                <nav class="nav-primary hidden md:flex items-center gap-6 text-sm font-medium text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                    <?php
+                    wp_nav_menu(
+                        array(
+                            'theme_location' => 'primary',
+                            'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
+                            'container'      => false,
+                            'fallback_cb'    => 'wp_page_menu',
+                        )
+                    );
+                    ?>
+                </nav>
+
+                <div class="hidden md:flex items-center gap-3">
+                    <button type="button" class="text-gray-600 hover:text-orange-500">
+                        <i data-lucide="search" class="w-5 h-5"></i>
+                        <span class="sr-only"><?php esc_html_e( 'Cerca', 'poetheme' ); ?></span>
+                    </button>
+                    <button type="button" class="text-gray-600 hover:text-orange-500">
+                        <i data-lucide="user" class="w-5 h-5"></i>
+                        <span class="sr-only"><?php esc_html_e( 'Account', 'poetheme' ); ?></span>
+                    </button>
+                    <?php if ( '' !== $cta_text ) : ?>
+                        <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex items-center px-4 py-2 rounded-full bg-orange-500 text-white font-semibold shadow hover:bg-orange-600 transition">
+                            <?php echo esc_html( $cta_text ); ?>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden border-b border-gray-100 bg-white" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <div class="flex items-center gap-4 text-gray-600">
+                <button type="button" class="p-2 rounded-full border border-gray-200 hover:border-orange-500 hover:text-orange-500 transition">
+                    <i data-lucide="search" class="w-5 h-5"></i>
+                    <span class="sr-only"><?php esc_html_e( 'Cerca', 'poetheme' ); ?></span>
+                </button>
+                <button type="button" class="p-2 rounded-full border border-gray-200 hover:border-orange-500 hover:text-orange-500 transition">
+                    <i data-lucide="user" class="w-5 h-5"></i>
+                    <span class="sr-only"><?php esc_html_e( 'Account', 'poetheme' ); ?></span>
+                </button>
+            </div>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-full bg-orange-500 text-white font-semibold shadow hover:bg-orange-600 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>

--- a/template-parts/header/style-8.php
+++ b/template-parts/header/style-8.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Header layout: Style 8 (E-commerce).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+    $args = array();
+}
+
+$defaults = array(
+    'show_top_bar'       => false,
+    'top_bar_texts'      => array( '', '', '' ),
+    'social_links'       => array(),
+    'social_definitions' => poetheme_get_header_social_networks(),
+    'cta_text'           => '',
+    'cta_url'            => '',
+);
+
+$context = wp_parse_args( $args, $defaults );
+$top_bar_texts = array_pad( array_map( 'trim', (array) $context['top_bar_texts'] ), 3, '' );
+$social_links  = is_array( $context['social_links'] ) ? $context['social_links'] : array();
+$cta_text      = trim( (string) $context['cta_text'] );
+$cta_url       = $context['cta_url'];
+$show_top_bar  = ! empty( $context['show_top_bar'] );
+
+$has_top_texts = array_filter( $top_bar_texts, 'strlen' );
+$has_social    = false;
+foreach ( $social_links as $link ) {
+    if ( ! empty( $link ) ) {
+        $has_social = true;
+        break;
+    }
+}
+
+$has_top_menu = has_nav_menu( 'top-info' );
+
+?>
+<header class="relative bg-white shadow-sm" role="banner" x-data="{ mobileOpen: false, searchOpen: false }">
+    <?php if ( $show_top_bar && ( $has_top_texts || $has_social || $has_top_menu ) ) : ?>
+        <div class="bg-indigo-900 text-white text-xs">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <?php if ( $has_top_texts ) : ?>
+                    <div class="flex flex-wrap items-center gap-x-5 gap-y-1 text-indigo-100">
+                        <?php foreach ( $top_bar_texts as $text ) : ?>
+                            <?php if ( '' === $text ) : continue; endif; ?>
+                            <span><?php echo esc_html( $text ); ?></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6 md:ml-auto">
+                    <?php if ( $has_top_menu ) : ?>
+                        <nav aria-label="<?php esc_attr_e( 'Supporto rapido', 'poetheme' ); ?>" class="text-indigo-100">
+                            <?php
+                            wp_nav_menu(
+                                array(
+                                    'theme_location' => 'top-info',
+                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'container'      => false,
+                                    'depth'          => 1,
+                                    'fallback_cb'    => false,
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php endif; ?>
+
+                    <?php if ( $has_social ) : ?>
+                        <div class="flex items-center gap-3 text-indigo-100">
+                            <?php foreach ( $context['social_definitions'] as $key => $social ) :
+                                $url = isset( $social_links[ $key ] ) ? $social_links[ $key ] : '';
+                                if ( empty( $url ) ) {
+                                    continue;
+                                }
+                                ?>
+                                <a class="hover:text-white transition" href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener">
+                                    <span class="sr-only"><?php echo esc_html( $social['label'] ); ?></span>
+                                    <i data-lucide="<?php echo esc_attr( $social['icon'] ); ?>" class="w-4 h-4"></i>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+
+    <div class="border-b border-indigo-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-6">
+            <button type="button" class="md:hidden text-gray-700" @click="mobileOpen = ! mobileOpen" aria-expanded="false">
+                <span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+                <i data-lucide="menu" class="w-6 h-6"></i>
+            </button>
+
+            <?php poetheme_the_logo(); ?>
+
+            <div class="hidden md:flex flex-1 items-center">
+                <form role="search" method="get" class="w-full" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+                    <label for="poetheme-header-search" class="sr-only"><?php esc_html_e( 'Cerca prodotti', 'poetheme' ); ?></label>
+                    <div class="relative">
+                        <input id="poetheme-header-search" type="search" name="s" class="w-full rounded-full border border-indigo-200 bg-indigo-50 pl-10 pr-4 py-2 text-sm focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200" placeholder="<?php esc_attr_e( 'Cerca prodotti...', 'poetheme' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" />
+                        <i data-lucide="search" class="w-4 h-4 text-indigo-400 absolute left-3 top-2.5"></i>
+                    </div>
+                </form>
+            </div>
+
+            <div class="flex items-center gap-3 ml-auto">
+                <button type="button" class="md:hidden text-gray-700" @click="searchOpen = ! searchOpen" aria-expanded="false">
+                    <span class="sr-only"><?php esc_html_e( 'Apri ricerca', 'poetheme' ); ?></span>
+                    <i data-lucide="search" class="w-6 h-6"></i>
+                </button>
+                <button type="button" class="text-gray-700 hover:text-indigo-600">
+                    <i data-lucide="user" class="w-6 h-6"></i>
+                    <span class="sr-only"><?php esc_html_e( 'Account', 'poetheme' ); ?></span>
+                </button>
+                <button type="button" class="relative text-gray-700 hover:text-indigo-600">
+                    <i data-lucide="shopping-cart" class="w-6 h-6"></i>
+                    <span class="absolute -top-1 -right-1 inline-flex items-center justify-center w-5 h-5 text-xs font-semibold text-white bg-indigo-600 rounded-full">3</span>
+                    <span class="sr-only"><?php esc_html_e( 'Carrello', 'poetheme' ); ?></span>
+                </button>
+                <?php if ( '' !== $cta_text ) : ?>
+                    <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="hidden sm:inline-flex items-center px-4 py-2 rounded-full bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">
+                        <?php echo esc_html( $cta_text ); ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div class="hidden md:block border-b border-indigo-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <nav class="nav-primary flex items-center gap-6 text-sm font-medium text-gray-700 py-3" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+        </div>
+    </div>
+
+    <div x-show="searchOpen" x-cloak class="md:hidden border-b border-indigo-100 bg-indigo-50" @keydown.escape.window="searchOpen = false">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+            <form role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+                <label for="poetheme-header-search-mobile" class="sr-only"><?php esc_html_e( 'Cerca prodotti', 'poetheme' ); ?></label>
+                <div class="relative">
+                    <input id="poetheme-header-search-mobile" type="search" name="s" class="w-full rounded-full border border-indigo-200 bg-white pl-10 pr-4 py-2 text-sm focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200" placeholder="<?php esc_attr_e( 'Cerca prodotti...', 'poetheme' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" />
+                    <i data-lucide="search" class="w-4 h-4 text-indigo-400 absolute left-3 top-2.5"></i>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div x-show="mobileOpen" x-cloak class="md:hidden bg-white border-b border-indigo-100" @keydown.escape.window="mobileOpen = false">
+        <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
+            <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'container'      => false,
+                        'fallback_cb'    => 'wp_page_menu',
+                    )
+                );
+                ?>
+            </nav>
+
+            <?php if ( '' !== $cta_text ) : ?>
+                <a href="<?php echo esc_url( $cta_url ? $cta_url : home_url( '/' ) ); ?>" class="inline-flex w-full justify-center items-center px-5 py-3 rounded-full bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">
+                    <?php echo esc_html( $cta_text ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+    </div>
+</header>


### PR DESCRIPTION
## Summary
- introduce header option defaults, sanitization, and admin UI so the site admin can pick between eight responsive header layouts, toggle the top bar, manage CTA copy, and set social URLs
- register a dedicated Top Info Menu location, add header context helpers, and load layout-specific template parts from the main header
- add eight responsive header templates covering classic, centered, minimal, showcase, overlay, sticky, promo, and e-commerce variants with dynamic menus, social icons, and mobile experiences

## Testing
- php -l header.php
- php -l inc/theme-options.php
- php -l inc/template-tags.php
- for f in template-parts/header/style-*.php; do php -l "$f"; done


------
https://chatgpt.com/codex/tasks/task_e_68dfecfc8fe48332970ce3e99a755a2f