### PR TITLE
Add configurable mega menu support

### DIFF
--- a/assets/css/menu-icon-picker.css
+++ b/assets/css/menu-icon-picker.css
@@ -1,0 +1,80 @@
+.poetheme-menu-field {
+    margin-top: 1rem;
+}
+
+.poetheme-icon-picker {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: start;
+}
+
+.poetheme-icon-picker__input {
+    grid-column: 1 / span 2;
+}
+
+.poetheme-icon-picker__preview {
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    background: #fff;
+}
+
+.poetheme-icon-picker__panel {
+    grid-column: 1 / span 2;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+}
+
+.poetheme-icon-picker__panel > summary {
+    cursor: pointer;
+    font-weight: 600;
+    outline: none;
+}
+
+.poetheme-icon-picker__grid {
+    margin-top: 0.75rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.5rem;
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.poetheme-icon-picker__option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    background: #fff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.poetheme-icon-picker__option:hover,
+.poetheme-icon-picker__option:focus {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 2px rgba(99,102,241,0.15);
+    outline: none;
+}
+
+.poetheme-icon-picker__option-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+}
+
+.poetheme-icon-picker__option-label {
+    font-size: 0.875rem;
+    color: #1f2937;
+}

--- a/assets/js/mega-menu.js
+++ b/assets/js/mega-menu.js
@@ -1,0 +1,15 @@
+(function(){
+    function megaMenuController() {
+        return {
+            isOpen: false,
+            open() {
+                this.isOpen = true;
+            },
+            close() {
+                this.isOpen = false;
+            }
+        };
+    }
+
+    window.poethemeMegaMenu = megaMenuController;
+})();

--- a/assets/js/menu-icon-picker.js
+++ b/assets/js/menu-icon-picker.js
@@ -1,0 +1,54 @@
+(function(){
+    function updatePreview(inputId, icon) {
+        var preview = document.querySelector('.poetheme-icon-picker__preview[data-target="' + inputId + '"]');
+        if (!preview) {
+            return;
+        }
+
+        preview.innerHTML = icon ? '<i data-lucide="' + icon + '" class="w-5 h-5"></i>' : '';
+        if (window.lucide) {
+            window.lucide.createIcons({root: preview});
+        }
+    }
+
+    function handleIconSelect(event) {
+        var target = event.target.closest('.poetheme-icon-picker__option');
+        if (!target) {
+            return;
+        }
+
+        event.preventDefault();
+
+        var icon  = target.getAttribute('data-icon');
+        var inputId = target.getAttribute('data-target');
+        var input = document.getElementById(inputId);
+
+        if (!input) {
+            return;
+        }
+
+        input.value = icon;
+        updatePreview(inputId, icon);
+    }
+
+    function initPicker(container) {
+        if (!container) {
+            return;
+        }
+
+        container.addEventListener('click', handleIconSelect);
+
+        var input = container.querySelector('.poetheme-icon-picker__input');
+        if (input) {
+            input.addEventListener('input', function(){
+                updatePreview(input.id, input.value.trim());
+            });
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        document.querySelectorAll('.poetheme-icon-picker').forEach(function(picker){
+            initPicker(picker);
+        });
+    });
+})();

--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,8 @@ define( 'POETHEME_URI', get_template_directory_uri() );
 require_once POETHEME_DIR . '/inc/theme-options.php';
 require_once POETHEME_DIR . '/inc/template-tags.php';
 require_once POETHEME_DIR . '/inc/schema-jsonld.php';
+require_once POETHEME_DIR . '/inc/class-poetheme-mega-menu-walker.php';
+require_once POETHEME_DIR . '/inc/mega-menu.php';
 
 if ( ! function_exists( 'poetheme_setup' ) ) {
     /**
@@ -120,6 +122,8 @@ function poetheme_scripts() {
         'poetheme-lucide',
         'document.addEventListener("DOMContentLoaded",function(){if(window.lucide){window.lucide.createIcons();}});'
     );
+
+    wp_enqueue_script( 'poetheme-mega-menu', POETHEME_URI . '/assets/js/mega-menu.js', array( 'poetheme-alpine' ), POETHEME_VERSION, true );
 }
 add_action( 'wp_enqueue_scripts', 'poetheme_scripts' );
 

--- a/inc/class-poetheme-mega-menu-walker.php
+++ b/inc/class-poetheme-mega-menu-walker.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Mega menu walker for PoeTheme.
+ *
+ * @package PoeTheme
+ */
+
+if ( ! class_exists( 'PoeTheme_Mega_Menu_Walker' ) ) {
+    /**
+     * Custom walker that renders a mega menu when children are present.
+     */
+    class PoeTheme_Mega_Menu_Walker extends Walker_Nav_Menu {
+        /**
+         * Keep track of items that have children to close wrappers properly.
+         *
+         * @var array<int, bool>
+         */
+        protected $items_with_children = array();
+
+        /**
+         * Start the list before the elements are added.
+         *
+         * @param string $output Passed by reference. Used to append additional content.
+         * @param int    $depth  Depth of menu item. Used for padding.
+         * @param array  $args   An array of arguments. @see wp_nav_menu().
+         */
+        public function start_lvl( &$output, $depth = 0, $args = array() ) {
+            if ( 0 === $depth ) {
+                $output .= "\n<div class=\"mega-menu-bridge\" x-show=\"isOpen\" x-cloak></div>";
+                $output .= "\n<div class=\"mega-menu-dropdown align-left bg-white shadow-2xl rounded-lg p-6\" x-show=\"isOpen\" x-transition.opacity.duration.200ms x-cloak :class=\"{ 'is-open': isOpen }\">";
+                $output .= "\n    <div class=\"mega-menu-grid grid gap-6 sm:grid-cols-2 lg:grid-cols-3\">";
+            } elseif ( 1 === $depth ) {
+                $output .= "\n        <ul class=\"mega-menu-links space-y-2 ml-7\">";
+            } else {
+                $output .= "\n<ul class=\"sub-menu\">";
+            }
+        }
+
+        /**
+         * Ends the list of after the elements are added.
+         *
+         * @param string $output Passed by reference. Used to append additional content.
+         * @param int    $depth  Depth of menu item. Used for padding.
+         * @param array  $args   An array of arguments. @see wp_nav_menu().
+         */
+        public function end_lvl( &$output, $depth = 0, $args = array() ) {
+            if ( 0 === $depth ) {
+                $output .= "\n    </div>"; // .mega-menu-grid.
+                $output .= "\n</div>"; // .mega-menu-dropdown.
+            } elseif ( 1 === $depth ) {
+                $output .= "\n        </ul>";
+            } else {
+                $output .= "\n</ul>";
+            }
+        }
+
+        /**
+         * Starts the element output.
+         *
+         * @param string   $output            Passed by reference. Used to append additional content.
+         * @param WP_Post  $item              Menu item data object.
+         * @param int      $depth             Depth of menu item. Used for padding.
+         * @param stdClass $args              An object of wp_nav_menu() arguments.
+         * @param int      $id                Current item ID.
+         */
+        public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+            $has_children = ! empty( $args->has_children );
+            if ( $has_children ) {
+                $this->items_with_children[ $item->ID ] = true;
+            }
+
+            $title = apply_filters( 'the_title', $item->title, $item->ID );
+            $is_title = (bool) get_post_meta( $item->ID, '_poetheme_menu_is_title', true );
+            $icon     = trim( (string) get_post_meta( $item->ID, '_poetheme_menu_icon', true ) );
+
+            $atts          = array();
+            $atts['title'] = ! empty( $item->attr_title ) ? $item->attr_title : '';
+            $atts['target'] = ! empty( $item->target ) ? $item->target : '';
+            $atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
+            $atts['href']   = ! empty( $item->url ) ? $item->url : '';
+
+            $attributes = '';
+            foreach ( $atts as $attr => $value ) {
+                if ( '' === $value ) {
+                    continue;
+                }
+
+                if ( 'href' === $attr ) {
+                    $value = esc_url( $value );
+                } else {
+                    $value = esc_attr( $value );
+                }
+
+                $attributes .= ' ' . $attr . '="' . $value . '"';
+            }
+
+            $icon_html = '';
+            if ( $icon ) {
+                $icon_html = '<i data-lucide="' . esc_attr( $icon ) . '" class="w-5 h-5"></i>';
+            }
+
+            $title_classes = $is_title ? 'font-semibold text-gray-900' : 'font-medium text-gray-700';
+
+            if ( 0 === $depth ) {
+                $class_names = empty( $item->classes ) ? array() : (array) $item->classes;
+                $class_names = array_filter( $class_names, 'strlen' );
+                $class_names = implode( ' ', array_map( 'sanitize_html_class', $class_names ) );
+                $class_attribute = trim( 'menu-item depth-0 ' . $class_names );
+
+                $output .= '<li class="' . esc_attr( $class_attribute ) . '">';
+
+                if ( $has_children ) {
+                    $output .= '<div class="mega-menu-wrapper relative" x-data="poethemeMegaMenu()" @mouseenter="open()" @mouseleave="close()" @focusin="open()" @focusout.window="close()" @keydown.escape.window="close()">';
+                    $output .= '<a' . $attributes . ' class="nav-link inline-flex items-center gap-2 transition-colors duration-150">' . $icon_html . '<span class="' . esc_attr( $title_classes ) . '">' . esc_html( $title ) . '</span><i data-lucide="chevron-down" class="w-4 h-4"></i></a>';
+                } else {
+                    $output .= '<a' . $attributes . ' class="nav-link inline-flex items-center gap-2 transition-colors duration-150">' . $icon_html . '<span class="' . esc_attr( $title_classes ) . '">' . esc_html( $title ) . '</span></a>';
+                }
+            } elseif ( 1 === $depth ) {
+                $output .= '\n        <div class="mega-menu-group">';
+                $link_classes = 'mega-menu-heading inline-flex items-center gap-2 text-sm text-gray-900';
+                if ( $is_title ) {
+                    $link_classes .= ' font-semibold';
+                } else {
+                    $link_classes .= ' font-medium';
+                }
+
+                if ( $atts['href'] ) {
+                    $output .= '<a' . $attributes . ' class="' . esc_attr( $link_classes ) . '">' . $icon_html . '<span>' . esc_html( $title ) . '</span></a>';
+                } else {
+                    $output .= '<div class="' . esc_attr( $link_classes ) . '">' . $icon_html . '<span>' . esc_html( $title ) . '</span></div>';
+                }
+            } else {
+                $output .= '\n            <li class="menu-item depth-' . intval( $depth ) . '">';
+                $link_classes = 'inline-flex items-center gap-2 text-sm text-gray-600 hover:text-blue-600 transition';
+                if ( $is_title ) {
+                    $link_classes .= ' font-semibold';
+                }
+
+                $output .= '<a' . $attributes . ' class="' . esc_attr( $link_classes ) . '">' . $icon_html . '<span>' . esc_html( $title ) . '</span></a>';
+            }
+        }
+
+        /**
+         * Ends the element output, if needed.
+         *
+         * @param string   $output Passed by reference. Used to append additional content.
+         * @param WP_Post  $item   Page data object. Not used.
+         * @param int      $depth  Depth of menu item. Used for padding.
+         * @param stdClass $args   An object of wp_nav_menu() arguments.
+         */
+        public function end_el( &$output, $item, $depth = 0, $args = array() ) {
+            if ( 0 === $depth ) {
+                if ( isset( $this->items_with_children[ $item->ID ] ) ) {
+                    $output .= '</div>'; // .mega-menu-wrapper.
+                    unset( $this->items_with_children[ $item->ID ] );
+                }
+
+                $output .= '</li>';
+            } elseif ( 1 === $depth ) {
+                $output .= '\n        </div>';
+            } else {
+                $output .= '</li>';
+            }
+        }
+    }
+}

--- a/inc/mega-menu.php
+++ b/inc/mega-menu.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Mega menu helpers and admin fields.
+ *
+ * @package PoeTheme
+ */
+
+/**
+ * Retrieve the list of Lucide icons used in the picker.
+ *
+ * @return string[]
+ */
+function poetheme_get_lucide_icons() {
+    return array(
+        'activity',
+        'airplay',
+        'alarm-check',
+        'alarm-clock',
+        'alarm-minus',
+        'alarm-plus',
+        'alert-circle',
+        'archive',
+        'arrow-right',
+        'award',
+        'badge-check',
+        'bell',
+        'book',
+        'bookmark',
+        'briefcase',
+        'building',
+        'calendar',
+        'camera',
+        'chart-bar',
+        'check-circle',
+        'clipboard-list',
+        'clock',
+        'cloud',
+        'code',
+        'compass',
+        'database',
+        'file-text',
+        'globe',
+        'headphones',
+        'heart',
+        'help-circle',
+        'home',
+        'inbox',
+        'layers',
+        'layout',
+        'life-buoy',
+        'link',
+        'list',
+        'lock',
+        'mail',
+        'map',
+        'megaphone',
+        'menu',
+        'message-circle',
+        'monitor',
+        'palette',
+        'phone',
+        'pie-chart',
+        'play-circle',
+        'settings',
+        'shield',
+        'shopping-bag',
+        'shopping-cart',
+        'smartphone',
+        'sparkles',
+        'star',
+        'tag',
+        'trophy',
+        'truck',
+        'user',
+        'users',
+        'watch',
+        'zap',
+        'zoom-in',
+    );
+}
+
+/**
+ * Add custom mega menu fields to nav menu items.
+ *
+ * @param int      $item_id Menu item ID.
+ * @param WP_Post  $item    Menu item object.
+ * @param int      $depth   Depth of menu item.
+ */
+function poetheme_nav_menu_item_custom_fields( $item_id, $item, $depth, $args = array() ) {
+    $is_title   = (bool) get_post_meta( $item_id, '_poetheme_menu_is_title', true );
+    $icon_value = trim( (string) get_post_meta( $item_id, '_poetheme_menu_icon', true ) );
+    $icons      = poetheme_get_lucide_icons();
+    ?>
+    <div class="poetheme-menu-field poetheme-menu-field--title">
+        <label for="edit-menu-item-poetheme-title-<?php echo esc_attr( $item_id ); ?>" style="display:flex;align-items:center;gap:0.5rem;">
+            <input type="checkbox" id="edit-menu-item-poetheme-title-<?php echo esc_attr( $item_id ); ?>" name="menu-item-poetheme-title[<?php echo esc_attr( $item_id ); ?>]" value="1" <?php checked( $is_title ); ?> />
+            <span><?php esc_html_e( 'Usa questo elemento come titolo/colonna (applica grassetto)', 'poetheme' ); ?></span>
+        </label>
+    </div>
+    <div class="poetheme-menu-field poetheme-menu-field--icon">
+        <label for="edit-menu-item-poetheme-icon-<?php echo esc_attr( $item_id ); ?>">
+            <?php esc_html_e( 'Icona Lucide', 'poetheme' ); ?>
+        </label>
+        <div class="poetheme-icon-picker">
+            <input type="text" class="widefat poetheme-icon-picker__input" id="edit-menu-item-poetheme-icon-<?php echo esc_attr( $item_id ); ?>" name="menu-item-poetheme-icon[<?php echo esc_attr( $item_id ); ?>]" value="<?php echo esc_attr( $icon_value ); ?>" placeholder="<?php esc_attr_e( 'es. star', 'poetheme' ); ?>" />
+            <div class="poetheme-icon-picker__preview" data-target="edit-menu-item-poetheme-icon-<?php echo esc_attr( $item_id ); ?>">
+                <?php if ( $icon_value ) : ?>
+                    <i data-lucide="<?php echo esc_attr( $icon_value ); ?>" class="w-5 h-5"></i>
+                <?php endif; ?>
+            </div>
+            <details class="poetheme-icon-picker__panel">
+                <summary><?php esc_html_e( 'Mostra libreria icone', 'poetheme' ); ?></summary>
+                <div class="poetheme-icon-picker__grid">
+                    <?php foreach ( $icons as $icon ) : ?>
+                        <button type="button" class="poetheme-icon-picker__option" data-icon="<?php echo esc_attr( $icon ); ?>" data-target="edit-menu-item-poetheme-icon-<?php echo esc_attr( $item_id ); ?>">
+                            <span class="poetheme-icon-picker__option-icon"><i data-lucide="<?php echo esc_attr( $icon ); ?>" class="w-5 h-5"></i></span>
+                            <span class="poetheme-icon-picker__option-label"><?php echo esc_html( $icon ); ?></span>
+                        </button>
+                    <?php endforeach; ?>
+                </div>
+            </details>
+        </div>
+    </div>
+    <?php
+}
+add_action( 'wp_nav_menu_item_custom_fields', 'poetheme_nav_menu_item_custom_fields', 10, 4 );
+
+/**
+ * Save the custom mega menu fields.
+ *
+ * @param int $menu_id         Menu ID.
+ * @param int $menu_item_db_id Menu item ID.
+ */
+function poetheme_save_menu_item_custom_fields( $menu_id, $menu_item_db_id ) {
+    $is_title = isset( $_POST['menu-item-poetheme-title'][ $menu_item_db_id ] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+    if ( $is_title ) {
+        update_post_meta( $menu_item_db_id, '_poetheme_menu_is_title', 1 );
+    } else {
+        delete_post_meta( $menu_item_db_id, '_poetheme_menu_is_title' );
+    }
+
+    if ( isset( $_POST['menu-item-poetheme-icon'][ $menu_item_db_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+        $icon_value = sanitize_text_field( wp_unslash( $_POST['menu-item-poetheme-icon'][ $menu_item_db_id ] ) );
+        if ( $icon_value ) {
+            update_post_meta( $menu_item_db_id, '_poetheme_menu_icon', $icon_value );
+        } else {
+            delete_post_meta( $menu_item_db_id, '_poetheme_menu_icon' );
+        }
+    }
+}
+add_action( 'wp_update_nav_menu_item', 'poetheme_save_menu_item_custom_fields', 10, 2 );
+
+/**
+ * Enqueue admin assets for the menu editor.
+ *
+ * @param string $hook Current admin page hook.
+ */
+function poetheme_enqueue_menu_admin_assets( $hook ) {
+    if ( 'nav-menus.php' !== $hook ) {
+        return;
+    }
+
+    wp_enqueue_style( 'poetheme-menu-icon-picker', POETHEME_URI . '/assets/css/menu-icon-picker.css', array(), POETHEME_VERSION );
+    wp_enqueue_script( 'poetheme-menu-lucide', 'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', array(), POETHEME_VERSION, true );
+    wp_enqueue_script( 'poetheme-menu-icon-picker', POETHEME_URI . '/assets/js/menu-icon-picker.js', array( 'poetheme-menu-lucide' ), POETHEME_VERSION, true );
+    wp_add_inline_script( 'poetheme-menu-icon-picker', 'window.addEventListener("load",function(){if(window.lucide){window.lucide.createIcons();}});' );
+}
+add_action( 'admin_enqueue_scripts', 'poetheme_enqueue_menu_admin_assets' );

--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@ Tags: blog, accessibility-ready, custom-logo, custom-menu, rtl-language-support,
   --poetheme-focus-color: #1e40af;
 }
 
+[x-cloak] {
+  display: none !important;
+}
+
 .skip-link {
   position: absolute;
   top: -40px;
@@ -110,4 +114,46 @@ body.rtl .breadcrumbs {
 body.rtl .skip-link {
   left: auto;
   right: 0;
+}
+
+/* Mega menu */
+.mega-menu-wrapper {
+  position: relative;
+}
+
+.mega-menu-wrapper .mega-menu-dropdown {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  min-width: 18rem;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  z-index: 40;
+}
+
+.mega-menu-wrapper .mega-menu-dropdown.is-open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.mega-menu-wrapper .mega-menu-bridge {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: 0.5rem;
+  z-index: 30;
+}
+
+.mega-menu-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mega-menu-links li {
+  list-style: none;
 }

--- a/template-parts/header/style-1.php
+++ b/template-parts/header/style-1.php
@@ -120,6 +120,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex flex-wrap items-center gap-6 text-sm font-medium',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-2.php
+++ b/template-parts/header/style-2.php
@@ -120,6 +120,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex items-center gap-8 text-base font-semibold tracking-tight',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-3.php
+++ b/template-parts/header/style-3.php
@@ -119,6 +119,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                         'menu_class'     => 'flex items-center gap-10 text-xs font-semibold tracking-[0.35em] uppercase',
                         'container'      => false,
                         'fallback_cb'    => 'wp_page_menu',
+                        'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                        'depth'          => 3,
                     )
                 );
                 ?>

--- a/template-parts/header/style-4.php
+++ b/template-parts/header/style-4.php
@@ -120,6 +120,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex flex-wrap items-center gap-8 text-sm font-medium uppercase tracking-wide',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-5.php
+++ b/template-parts/header/style-5.php
@@ -125,6 +125,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex items-center gap-10 text-base font-medium uppercase tracking-wide',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-6.php
+++ b/template-parts/header/style-6.php
@@ -120,6 +120,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex items-center gap-8 text-sm font-semibold uppercase tracking-wide',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-7.php
+++ b/template-parts/header/style-7.php
@@ -133,6 +133,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                             'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
                             'container'      => false,
                             'fallback_cb'    => 'wp_page_menu',
+                            'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                            'depth'          => 3,
                         )
                     );
                     ?>

--- a/template-parts/header/style-8.php
+++ b/template-parts/header/style-8.php
@@ -153,6 +153,8 @@ $has_top_menu = has_nav_menu( 'top-info' );
                         'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
                         'container'      => false,
                         'fallback_cb'    => 'wp_page_menu',
+                        'walker'         => new PoeTheme_Mega_Menu_Walker(),
+                        'depth'          => 3,
                     )
                 );
                 ?>


### PR DESCRIPTION
## Summary
- add a custom mega menu walker and share it across all desktop header layouts
- expose Lucide icon and title controls for each menu item with an icon picker in the nav menu editor
- include front-end and admin assets to power the mega dropdown animations and icon selector styles

## Testing
- php -l inc/class-poetheme-mega-menu-walker.php
- php -l inc/mega-menu.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e1041e25008332b911ea9ce5a58312