### PR TITLE
Fix mega menu trigger interactions

### DIFF
--- a/assets/js/mega-menu.js
+++ b/assets/js/mega-menu.js
@@ -2,11 +2,39 @@
     function megaMenuController() {
         return {
             isOpen: false,
+            closeTimeout: null,
             open() {
+                if ( this.closeTimeout ) {
+                    clearTimeout( this.closeTimeout );
+                    this.closeTimeout = null;
+                }
+
                 this.isOpen = true;
             },
+            scheduleClose() {
+                if ( this.closeTimeout ) {
+                    clearTimeout( this.closeTimeout );
+                }
+
+                this.closeTimeout = setTimeout( () => {
+                    this.isOpen      = false;
+                    this.closeTimeout = null;
+                }, 200 );
+            },
             close() {
+                if ( this.closeTimeout ) {
+                    clearTimeout( this.closeTimeout );
+                    this.closeTimeout = null;
+                }
+
                 this.isOpen = false;
+            },
+            toggle() {
+                if ( this.isOpen ) {
+                    this.close();
+                } else {
+                    this.open();
+                }
             }
         };
     }

--- a/inc/class-poetheme-mega-menu-walker.php
+++ b/inc/class-poetheme-mega-menu-walker.php
@@ -26,8 +26,8 @@ if ( ! class_exists( 'PoeTheme_Mega_Menu_Walker' ) ) {
          */
         public function start_lvl( &$output, $depth = 0, $args = array() ) {
             if ( 0 === $depth ) {
-                $output .= "\n<div class=\"mega-menu-bridge\" x-show=\"isOpen\" x-cloak></div>";
-                $output .= "\n<div class=\"mega-menu-dropdown align-left bg-white shadow-2xl rounded-lg p-6\" x-show=\"isOpen\" x-transition.opacity.duration.200ms x-cloak :class=\"{ 'is-open': isOpen }\">";
+                $output .= "\n<div class=\"mega-menu-bridge\" x-show=\"isOpen\" x-cloak @mouseenter=\"open()\" @mouseleave=\"scheduleClose()\"></div>";
+                $output .= "\n<div class=\"mega-menu-dropdown align-left bg-white shadow-2xl rounded-lg p-6\" x-show=\"isOpen\" x-transition.opacity.duration.200ms x-cloak :class=\"{ 'is-open': isOpen }\" @mouseenter=\"open()\" @mouseleave=\"scheduleClose()\">";
                 $output .= "\n    <div class=\"mega-menu-grid grid gap-6 sm:grid-cols-2 lg:grid-cols-3\">";
             } elseif ( 1 === $depth ) {
                 $output .= "\n        <ul class=\"mega-menu-links space-y-2 ml-7\">";
@@ -113,8 +113,13 @@ if ( ! class_exists( 'PoeTheme_Mega_Menu_Walker' ) ) {
                 $output .= '<li class="' . esc_attr( $class_attribute ) . '">';
 
                 if ( $has_children ) {
-                    $output .= '<div class="mega-menu-wrapper relative" x-data="poethemeMegaMenu()" @mouseenter="open()" @mouseleave="close()" @focusin="open()" @focusout.window="close()" @keydown.escape.window="close()">';
-                    $output .= '<a' . $attributes . ' class="nav-link inline-flex items-center gap-2 transition-colors duration-150">' . $icon_html . '<span class="' . esc_attr( $title_classes ) . '">' . esc_html( $title ) . '</span><i data-lucide="chevron-down" class="w-4 h-4"></i></a>';
+                    $title_attribute = '';
+                    if ( ! empty( $atts['title'] ) ) {
+                        $title_attribute = ' title="' . esc_attr( $atts['title'] ) . '"';
+                    }
+
+                    $output .= '<div class="mega-menu-wrapper relative" x-data="poethemeMegaMenu()" @mouseenter="open()" @mouseleave="scheduleClose()" @focusin="open()" @focusout.window="close()" @keydown.escape.window="close()">';
+                    $output .= '<button type="button" class="mega-menu-trigger nav-link inline-flex items-center gap-2 transition-colors duration-150" aria-haspopup="true" x-bind:aria-expanded="isOpen ? \'true\' : \'false\'" @mouseenter="open()" @mouseleave="scheduleClose()" @click="toggle()"' . $title_attribute . '>' . $icon_html . '<span class="' . esc_attr( $title_classes ) . '">' . esc_html( $title ) . '</span><i data-lucide="chevron-down" class="w-4 h-4"></i></button>';
                 } else {
                     $output .= '<a' . $attributes . ' class="nav-link inline-flex items-center gap-2 transition-colors duration-150">' . $icon_html . '<span class="' . esc_attr( $title_classes ) . '">' . esc_html( $title ) . '</span></a>';
                 }

--- a/style.css
+++ b/style.css
@@ -121,6 +121,20 @@ body.rtl .skip-link {
   position: relative;
 }
 
+.mega-menu-trigger {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.mega-menu-trigger:focus {
+  outline: 3px solid var(--poetheme-focus-color);
+  outline-offset: 2px;
+}
+
 .mega-menu-wrapper .mega-menu-dropdown {
   position: absolute;
   top: calc(100% + 0.5rem);


### PR DESCRIPTION
## Summary
- update the mega menu walker to render button triggers with hover delay handling that mirrors the reference markup
- extend the Alpine controller with toggle and scheduled close helpers to keep dropdowns open while hovering
- add styling for the new button trigger so it looks and focuses like a regular navigation link

## Testing
- php -l inc/class-poetheme-mega-menu-walker.php

------
https://chatgpt.com/codex/tasks/task_e_68e113fc06248332a15e002b39792a53