### PR TITLE
Prevent mega menu placeholders from opening blank tabs

### DIFF
--- a/inc/class-poetheme-mega-menu-walker.php
+++ b/inc/class-poetheme-mega-menu-walker.php
@@ -81,6 +81,11 @@ if ( ! class_exists( 'PoeTheme_Mega_Menu_Walker' ) ) {
             $atts['target']  = ! empty( $item->target ) ? $item->target : '';
             $atts['rel']     = ! empty( $item->xfn ) ? $item->xfn : '';
             $atts['href']    = ! empty( $item->url ) ? $item->url : '';
+
+            if ( in_array( trim( (string) $atts['href'] ), array( '', '#', '#0', '#!' ), true ) ) {
+                $atts['href']   = '';
+                $atts['target'] = '';
+            }
             $atts['aria-haspopup'] = $has_children ? 'true' : '';
             $atts['aria-expanded'] = $has_children ? 'false' : '';
 


### PR DESCRIPTION
## Summary
- prevent mega menu entries without real URLs from keeping a _blank target that causes empty tabs to open

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11678708883328059ed3fa2f770ac