### PR TITLE
Add dropdown menu walker with Lucide icon picker

### DIFF
--- a/assets/css/menu-icons.css
+++ b/assets/css/menu-icons.css
@@ -1,0 +1,187 @@
+.poetheme-menu-icon-field {
+    margin-top: 1em;
+}
+
+.poetheme-menu-icon-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.poetheme-menu-icon-preview {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 13px;
+    color: #1f2937;
+}
+
+.poetheme-menu-icon-example svg,
+.poetheme-menu-icon-example i {
+    width: 18px;
+    height: 18px;
+}
+
+.poetheme-menu-icon-placeholder {
+    color: #6b7280;
+    font-style: italic;
+}
+
+.poetheme-menu-icon-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.poetheme-icon-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100000;
+    padding: 1.5rem;
+}
+
+.poetheme-icon-modal-backdrop.is-visible {
+    display: flex;
+}
+
+.poetheme-icon-modal {
+    width: min(900px, 100%);
+    max-height: 85vh;
+    background: #ffffff;
+    border-radius: 14px;
+    box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.poetheme-icon-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.poetheme-icon-modal__header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.poetheme-icon-modal__close {
+    background: none;
+    border: none;
+    color: #6b7280;
+    cursor: pointer;
+    font-size: 1.25rem;
+}
+
+.poetheme-icon-modal__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.poetheme-icon-modal__filters button {
+    border: 1px solid #d1d5db;
+    background: #f9fafb;
+    color: #374151;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+}
+
+.poetheme-icon-modal__filters button.is-active,
+.poetheme-icon-modal__filters button:hover {
+    border-color: #6366f1;
+    background: #eef2ff;
+    color: #312e81;
+}
+
+.poetheme-icon-modal__search {
+    padding: 0 1.25rem 0.75rem 1.25rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.poetheme-icon-modal__search input[type="search"] {
+    width: 100%;
+    border: 1px solid #d1d5db;
+    border-radius: 9999px;
+    padding: 0.6rem 1rem;
+    font-size: 0.9rem;
+    transition: border-color 0.2s ease;
+}
+
+.poetheme-icon-modal__search input[type="search"]:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.poetheme-icon-modal__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem 1.25rem 1.5rem;
+}
+
+.poetheme-icon-modal__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.75rem;
+}
+
+.poetheme-icon-option {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid #e5e7eb;
+    background: #ffffff;
+    color: #111827;
+    cursor: pointer;
+    transition: all 0.15s ease-in-out;
+}
+
+.poetheme-icon-option svg,
+.poetheme-icon-option i {
+    width: 22px;
+    height: 22px;
+}
+
+.poetheme-icon-option:hover,
+.poetheme-icon-option:focus {
+    border-color: #6366f1;
+    box-shadow: 0 8px 20px -10px rgba(99, 102, 241, 0.45);
+    outline: none;
+}
+
+.poetheme-icon-option span {
+    font-size: 0.75rem;
+    text-transform: lowercase;
+    color: #4b5563;
+    word-break: break-all;
+}
+
+.poetheme-icon-modal__empty {
+    text-align: center;
+    padding: 2rem 1rem;
+    color: #6b7280;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 600px) {
+    .poetheme-icon-modal__grid {
+        grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    }
+}

--- a/assets/js/menu-icons.js
+++ b/assets/js/menu-icons.js
@@ -1,0 +1,253 @@
+(function ($) {
+    'use strict';
+
+    const config = window.poethemeMenuIcons || {};
+    const groups = Array.isArray(config.groups) ? config.groups : [];
+    let modalBackdrop;
+    let modal;
+    let searchInput;
+    let gridContainer;
+    let emptyState;
+    let activeInput = null;
+    let currentGroup = 'all';
+
+    function createModal() {
+        if (modalBackdrop) {
+            return;
+        }
+
+        modalBackdrop = $('<div>', {
+            class: 'poetheme-icon-modal-backdrop',
+            'aria-hidden': 'true'
+        });
+
+        modal = $('<div>', {
+            class: 'poetheme-icon-modal',
+            role: 'dialog',
+            'aria-modal': 'true'
+        }).appendTo(modalBackdrop);
+
+        const header = $('<div>', { class: 'poetheme-icon-modal__header' }).appendTo(modal);
+        $('<h2>', { text: config.selectLabel || 'Seleziona icona' }).appendTo(header);
+        $('<button>', {
+            type: 'button',
+            class: 'poetheme-icon-modal__close',
+            html: '&times;'
+        }).appendTo(header).on('click', closeModal);
+
+        const filters = $('<div>', { class: 'poetheme-icon-modal__filters' }).appendTo(modal);
+        const allButton = $('<button>', {
+            type: 'button',
+            text: config.allLabel || 'Tutte',
+            class: 'is-active',
+            'data-group': 'all'
+        }).appendTo(filters);
+        allButton.on('click', () => setGroup('all', allButton));
+
+        groups.forEach((group, index) => {
+            const button = $('<button>', {
+                type: 'button',
+                text: group.label || `Gruppo ${index + 1}`,
+                'data-group': String(index)
+            });
+            button.on('click', () => setGroup(String(index), button));
+            filters.append(button);
+        });
+
+        const searchWrapper = $('<div>', { class: 'poetheme-icon-modal__search' }).appendTo(modal);
+        searchInput = $('<input>', {
+            type: 'search',
+            placeholder: config.searchLabel || 'Cerca icone...'
+        }).appendTo(searchWrapper);
+        searchInput.on('input', renderIcons);
+
+        const body = $('<div>', { class: 'poetheme-icon-modal__body' }).appendTo(modal);
+        gridContainer = $('<div>', { class: 'poetheme-icon-modal__grid' }).appendTo(body);
+        emptyState = $('<div>', {
+            class: 'poetheme-icon-modal__empty',
+            text: config.noResults || 'Nessuna icona trovata.'
+        }).appendTo(body);
+
+        $('body').append(modalBackdrop);
+
+        modalBackdrop.on('click', function (event) {
+            if ($(event.target).is(modalBackdrop)) {
+                closeModal();
+            }
+        });
+
+        $(document).on('keydown.poethemeIconPicker', function (event) {
+            if (event.key === 'Escape' && modalBackdrop.hasClass('is-visible')) {
+                closeModal();
+            }
+        });
+    }
+
+    function setGroup(group, button) {
+        currentGroup = group;
+        button.closest('.poetheme-icon-modal__filters').find('button').removeClass('is-active');
+        button.addClass('is-active');
+        renderIcons();
+    }
+
+    function filterIcons() {
+        const searchTerm = (searchInput ? searchInput.val() : '').trim().toLowerCase();
+        let iconList = [];
+
+        if ('all' === currentGroup) {
+            groups.forEach((group) => {
+                if (Array.isArray(group.icons)) {
+                    iconList = iconList.concat(group.icons);
+                }
+            });
+        } else {
+            const index = parseInt(currentGroup, 10);
+            if (!Number.isNaN(index) && groups[index] && Array.isArray(groups[index].icons)) {
+                iconList = groups[index].icons.slice();
+            }
+        }
+
+        if (searchTerm) {
+            iconList = iconList.filter((icon) => icon.toLowerCase().includes(searchTerm));
+        }
+
+        iconList = Array.from(new Set(iconList));
+
+        return iconList;
+    }
+
+    function renderIcons() {
+        if (!gridContainer) {
+            return;
+        }
+
+        gridContainer.empty();
+        const icons = filterIcons();
+
+        if (!icons.length) {
+            emptyState.show();
+            return;
+        }
+
+        emptyState.hide();
+
+        icons.forEach((icon) => {
+            const button = $('<button>', {
+                type: 'button',
+                class: 'poetheme-icon-option',
+                'data-icon': icon
+            });
+
+            $('<i>', { 'data-lucide': icon }).appendTo(button);
+            $('<span>', { text: icon }).appendTo(button);
+
+            button.on('click', () => selectIcon(icon));
+            gridContainer.append(button);
+        });
+
+        if (window.lucide && typeof window.lucide.createIcons === 'function') {
+            window.lucide.createIcons();
+        }
+    }
+
+    function openModal(input) {
+        createModal();
+        activeInput = $(input);
+        if (searchInput) {
+            searchInput.val('');
+        }
+        currentGroup = 'all';
+        if (modal) {
+            modal.find('.poetheme-icon-modal__filters button').removeClass('is-active').each(function (index) {
+                if (0 === index) {
+                    $(this).addClass('is-active');
+                }
+            });
+        }
+
+        modalBackdrop.addClass('is-visible').attr('aria-hidden', 'false');
+        renderIcons();
+        if (searchInput) {
+            setTimeout(() => searchInput.trigger('focus'), 50);
+        }
+    }
+
+    function closeModal() {
+        if (!modalBackdrop) {
+            return;
+        }
+
+        modalBackdrop.removeClass('is-visible').attr('aria-hidden', 'true');
+        activeInput = null;
+    }
+
+    function updatePreview($input) {
+        const preview = $input.closest('.poetheme-menu-icon-control').find('.poetheme-menu-icon-preview');
+        const value = ($input.val() || '').trim();
+        const emptyLabel = preview.data('empty-label') || '';
+
+        if (!value) {
+            preview.html('<span class="poetheme-menu-icon-placeholder">' + emptyLabel + '</span>');
+        } else {
+            const markup = '<span class="poetheme-menu-icon-example"><i data-lucide="' + value + '" class="w-4 h-4"></i></span>' +
+                '<span class="poetheme-menu-icon-name">' + value + '</span>';
+            preview.html(markup);
+        }
+
+        if (window.lucide && typeof window.lucide.createIcons === 'function') {
+            window.lucide.createIcons();
+        }
+    }
+
+    function selectIcon(icon) {
+        if (!activeInput) {
+            return;
+        }
+
+        activeInput.val(icon).trigger('change');
+        updatePreview(activeInput);
+        closeModal();
+    }
+
+    function clearIcon(target) {
+        const $input = $(target);
+        $input.val('');
+        updatePreview($input);
+    }
+
+    $(document).on('click', '.poetheme-open-icon-picker', function (event) {
+        event.preventDefault();
+        const target = $(this).data('target');
+        if (!target) {
+            return;
+        }
+
+        const $input = $(target);
+        if ($input.length) {
+            openModal($input);
+        }
+    });
+
+    $(document).on('click', '.poetheme-clear-icon', function (event) {
+        event.preventDefault();
+        const target = $(this).data('target');
+        if (!target) {
+            return;
+        }
+
+        const $input = $(target);
+        if ($input.length) {
+            clearIcon($input);
+        }
+    });
+
+    $(document).ready(function () {
+        $('.poetheme-menu-icon-input').each(function () {
+            updatePreview($(this));
+        });
+
+        if (window.lucide && typeof window.lucide.createIcons === 'function') {
+            window.lucide.createIcons();
+        }
+    });
+})(jQuery);

--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,7 @@ define( 'POETHEME_URI', get_template_directory_uri() );
 require_once POETHEME_DIR . '/inc/theme-options.php';
 require_once POETHEME_DIR . '/inc/template-tags.php';
 require_once POETHEME_DIR . '/inc/schema-jsonld.php';
+require_once POETHEME_DIR . '/inc/nav-menu.php';
 
 if ( ! function_exists( 'poetheme_setup' ) ) {
     /**

--- a/inc/nav-menu.php
+++ b/inc/nav-menu.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Navigation helpers and custom walkers.
+ *
+ * @package PoeTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
+    /**
+     * Custom walker used to render theme navigation menus.
+     */
+    class PoeTheme_Nav_Walker extends Walker_Nav_Menu {
+        /**
+         * Menu layout (primary or top-info).
+         *
+         * @var string
+         */
+        protected $layout = 'primary';
+
+        /**
+         * Menu variant (desktop or mobile).
+         *
+         * @var string
+         */
+        protected $variant = 'desktop';
+
+        /**
+         * Constructor.
+         *
+         * @param array|string $args Walker configuration.
+         */
+        public function __construct( $args = array() ) {
+            if ( is_string( $args ) ) {
+                $args = array( 'layout' => $args );
+            }
+
+            $args          = wp_parse_args(
+                $args,
+                array(
+                    'layout'  => 'primary',
+                    'variant' => 'desktop',
+                )
+            );
+            $this->layout  = $args['layout'];
+            $this->variant = $args['variant'];
+        }
+
+        /**
+         * Starts the list before the elements are added.
+         *
+         * @param string   $output Passed by reference. Used to append additional content.
+         * @param int      $depth  Depth of menu item. Used for padding.
+         * @param stdClass $args   An object of wp_nav_menu() arguments.
+         */
+        public function start_lvl( &$output, $depth = 0, $args = null ) {
+            $indent = str_repeat( "\t", $depth );
+
+            if ( 'mobile' === $this->variant ) {
+                $classes = array( 'poetheme-submenu', 'pl-4', 'border-l', 'border-gray-200', 'space-y-2', 'mt-2' );
+                if ( $depth > 0 ) {
+                    $classes[] = 'ml-2';
+                }
+
+                $output .= "\n{$indent}<ul class='" . esc_attr( implode( ' ', $classes ) ) . "'>\n";
+                return;
+            }
+
+            $classes = array(
+                'poetheme-submenu',
+                'absolute',
+                'z-30',
+                'hidden',
+                'bg-white',
+                'rounded-lg',
+                'shadow-lg',
+                'py-2',
+                'w-56',
+                'space-y-1',
+                'group-hover:block',
+                'group-focus-within:block',
+                'transition',
+                'duration-150',
+            );
+
+            if ( 0 === $depth ) {
+                $classes[] = 'left-0';
+                $classes[] = 'mt-2';
+            } else {
+                $classes[] = 'left-full';
+                $classes[] = 'top-0';
+                $classes[] = 'ml-1';
+            }
+
+            $output .= "\n{$indent}<ul class='" . esc_attr( implode( ' ', $classes ) ) . "'>\n";
+        }
+
+        /**
+         * Ends the list of after the elements are added.
+         *
+         * @param string   $output Passed by reference. Used to append additional content.
+         * @param int      $depth  Depth of menu item. Used for padding.
+         * @param stdClass $args   An object of wp_nav_menu() arguments.
+         */
+        public function end_lvl( &$output, $depth = 0, $args = null ) {
+            $indent = str_repeat( "\t", $depth );
+            $output .= "{$indent}</ul>\n";
+        }
+
+        /**
+         * Starts the element output.
+         *
+         * @param string   $output Passed by reference. Used to append additional content.
+         * @param WP_Post  $item   Menu item data object.
+         * @param int      $depth  Depth of menu item.
+         * @param stdClass $args   An object of wp_nav_menu() arguments.
+         * @param int      $id     Current item ID.
+         */
+        public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+            $indent      = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+            $classes     = empty( $item->classes ) ? array() : (array) $item->classes;
+            $classes[]   = 'menu-item-' . $item->ID;
+            $has_children = in_array( 'menu-item-has-children', $classes, true );
+
+            $li_classes = array( 'poetheme-menu-item', 'relative' );
+
+            if ( 'mobile' !== $this->variant && $has_children ) {
+                $li_classes[] = 'group';
+            }
+
+            if ( ! empty( $classes ) ) {
+                foreach ( $classes as $class ) {
+                    $sanitized = sanitize_html_class( $class );
+                    if ( $sanitized ) {
+                        $li_classes[] = $sanitized;
+                    }
+                }
+            }
+
+            $class_names = implode( ' ', array_unique( $li_classes ) );
+            $class_names = $class_names ? " class='" . esc_attr( $class_names ) . "'" : '';
+
+            $output .= $indent . '<li' . $class_names . '>';
+
+            $atts           = array();
+            $atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
+            $atts['target'] = ! empty( $item->target ) ? $item->target : '';
+            $atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
+            $atts['href']   = ! empty( $item->url ) ? $item->url : '';
+
+            if ( $has_children && 'mobile' !== $this->variant ) {
+                $atts['aria-haspopup'] = 'true';
+                $atts['aria-expanded'] = 'false';
+            }
+
+            $link_classes = $this->get_link_classes( $depth, $has_children, $item );
+            if ( $link_classes ) {
+                $atts['class'] = trim( $link_classes );
+            }
+
+            $atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+
+            $attributes = '';
+            foreach ( $atts as $attr => $value ) {
+                if ( empty( $value ) ) {
+                    continue;
+                }
+
+                $value      = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+                $attributes .= ' ' . $attr . '="' . $value . '"';
+            }
+
+            $title = apply_filters( 'the_title', $item->title, $item->ID );
+
+            $icon     = get_post_meta( $item->ID, 'poetheme_menu_icon', true );
+            $is_bold  = (bool) get_post_meta( $item->ID, 'poetheme_menu_bold', true );
+            $icon_svg = '';
+
+            if ( $icon ) {
+                $icon_svg = '<i data-lucide="' . esc_attr( $icon ) . '" class="w-4 h-4"></i>';
+            }
+
+            $indicator = '';
+            if ( $has_children ) {
+                $indicator_icon = ( 0 === $depth ) ? 'chevron-down' : 'chevron-right';
+                $indicator      = '<i data-lucide="' . esc_attr( $indicator_icon ) . '" class="w-4 h-4 ml-1 text-gray-400"></i>';
+            }
+
+            $title_markup = '<span class="menu-item-text' . ( $is_bold ? ' font-semibold' : '' ) . '">' . esc_html( $title ) . '</span>';
+
+            $item_output  = $args->before;
+            $item_output .= '<a' . $attributes . '>';
+            $item_output .= $args->link_before;
+
+            if ( $icon_svg ) {
+                $item_output .= '<span class="menu-item-icon">' . $icon_svg . '</span>';
+            }
+
+            $item_output .= $title_markup;
+
+            if ( $indicator ) {
+                $item_output .= $indicator;
+            }
+
+            $item_output .= $args->link_after;
+            $item_output .= '</a>';
+            $item_output .= $args->after;
+
+            $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+        }
+
+        /**
+         * Ends the element output, if needed.
+         *
+         * @param string   $output Passed by reference. Used to append additional content.
+         * @param WP_Post  $item   Page data object. Not used.
+         * @param int      $depth  Depth of menu item. Not Used.
+         * @param stdClass $args   An object of wp_nav_menu() arguments.
+         */
+        public function end_el( &$output, $item, $depth = 0, $args = null ) {
+            $output .= "</li>\n";
+        }
+
+        /**
+         * Build the CSS classes for a menu link.
+         *
+         * @param int     $depth        Menu depth.
+         * @param bool    $has_children Whether the item has children.
+         * @param WP_Post $item         The menu item.
+         *
+         * @return string
+         */
+        protected function get_link_classes( $depth, $has_children, $item ) {
+            $classes = array( 'inline-flex', 'items-center', 'gap-2', 'transition', 'duration-150', 'ease-out' );
+
+            if ( 'mobile' === $this->variant ) {
+                $classes = array( 'flex', 'items-center', 'gap-2', 'w-full', 'text-left', 'transition', 'duration-150' );
+                $classes[] = ( 0 === $depth ) ? 'text-base' : 'text-sm';
+                $classes[] = 'text-gray-800';
+                $classes[] = 'hover:text-blue-600';
+                $classes[] = 'py-1.5';
+                return implode( ' ', array_filter( $classes ) );
+            }
+
+            if ( 'top-info' === $this->layout ) {
+                if ( 0 === $depth ) {
+                    $classes[] = 'text-sm';
+                    $classes[] = 'text-gray-200';
+                    $classes[] = 'hover:text-white';
+                } else {
+                    $classes[] = 'px-4';
+                    $classes[] = 'py-2';
+                    $classes[] = 'text-sm';
+                    $classes[] = 'text-gray-700';
+                    $classes[] = 'hover:bg-gray-100';
+                }
+            } else {
+                if ( 0 === $depth ) {
+                    $classes[] = 'py-2';
+                    $classes[] = 'text-sm';
+                    $classes[] = 'text-gray-700';
+                    $classes[] = 'hover:text-blue-600';
+                } else {
+                    $classes[] = 'px-4';
+                    $classes[] = 'py-2';
+                    $classes[] = 'text-sm';
+                    $classes[] = 'text-gray-700';
+                    $classes[] = 'hover:bg-gray-100';
+                }
+            }
+
+            return implode( ' ', array_filter( $classes ) );
+        }
+    }
+}
+
+if ( ! function_exists( 'poetheme_render_navigation_menu' ) ) {
+    /**
+     * Helper function to render theme menus with the custom walker.
+     *
+     * @param string $location Menu location slug.
+     * @param string $variant  Menu variant (desktop or mobile).
+     * @param array  $args     Additional arguments passed to wp_nav_menu().
+     */
+    function poetheme_render_navigation_menu( $location, $variant = 'desktop', $args = array() ) {
+        $defaults = array(
+            'theme_location' => $location,
+            'container'      => false,
+            'depth'          => 3,
+        );
+
+        if ( 'top-info' === $location ) {
+            $defaults['fallback_cb'] = false;
+        } else {
+            $defaults['fallback_cb'] = 'wp_page_menu';
+        }
+
+        $walker_args         = array(
+            'layout'  => ( 'top-info' === $location ) ? 'top-info' : 'primary',
+            'variant' => ( 'mobile' === $variant ) ? 'mobile' : 'desktop',
+        );
+        $defaults['walker']   = new PoeTheme_Nav_Walker( $walker_args );
+
+        if ( 'mobile' === $variant ) {
+            $defaults['depth'] = 3;
+        }
+
+        $args = wp_parse_args( $args, $defaults );
+
+        wp_nav_menu( $args );
+    }
+}
+
+if ( ! function_exists( 'poetheme_menu_item_custom_fields' ) ) {
+    /**
+     * Output custom fields for nav menu items.
+     *
+     * @param int     $item_id Menu item ID.
+     * @param WP_Post $item    Menu item object.
+     */
+    function poetheme_menu_item_custom_fields( $item_id, $item, $depth, $args ) {
+        $is_bold   = (bool) get_post_meta( $item_id, 'poetheme_menu_bold', true );
+        $icon      = get_post_meta( $item_id, 'poetheme_menu_icon', true );
+        $icon_name = $icon ? $icon : '';
+        ?>
+        <p class="description description-wide poetheme-menu-bold-field">
+            <label for="poetheme-menu-bold-<?php echo esc_attr( $item_id ); ?>">
+                <input type="checkbox" id="poetheme-menu-bold-<?php echo esc_attr( $item_id ); ?>" name="poetheme_menu_bold[<?php echo esc_attr( $item_id ); ?>]" value="1" <?php checked( $is_bold ); ?> />
+                <?php esc_html_e( 'Mostra il testo in grassetto', 'poetheme' ); ?>
+            </label>
+        </p>
+        <div class="description description-wide poetheme-menu-icon-field">
+            <label for="poetheme-menu-icon-<?php echo esc_attr( $item_id ); ?>"><?php esc_html_e( 'Icona Lucide', 'poetheme' ); ?></label>
+            <div class="poetheme-menu-icon-control">
+                <input type="hidden" id="poetheme-menu-icon-<?php echo esc_attr( $item_id ); ?>" class="poetheme-menu-icon-input" name="poetheme_menu_icon[<?php echo esc_attr( $item_id ); ?>]" value="<?php echo esc_attr( $icon_name ); ?>" data-item-id="<?php echo esc_attr( $item_id ); ?>" />
+                <div class="poetheme-menu-icon-preview" data-empty-label="<?php esc_attr_e( 'Nessuna icona selezionata', 'poetheme' ); ?>">
+                    <?php if ( $icon_name ) : ?>
+                        <span class="poetheme-menu-icon-example"><i data-lucide="<?php echo esc_attr( $icon_name ); ?>" class="w-4 h-4"></i></span>
+                        <span class="poetheme-menu-icon-name"><?php echo esc_html( $icon_name ); ?></span>
+                    <?php else : ?>
+                        <span class="poetheme-menu-icon-placeholder"><?php esc_html_e( 'Nessuna icona selezionata', 'poetheme' ); ?></span>
+                    <?php endif; ?>
+                </div>
+                <div class="poetheme-menu-icon-actions">
+                    <button type="button" class="button button-secondary poetheme-open-icon-picker" data-target="#poetheme-menu-icon-<?php echo esc_attr( $item_id ); ?>"><?php esc_html_e( 'Scegli icona', 'poetheme' ); ?></button>
+                    <button type="button" class="button button-link-delete poetheme-clear-icon" data-target="#poetheme-menu-icon-<?php echo esc_attr( $item_id ); ?>"><?php esc_html_e( 'Rimuovi icona', 'poetheme' ); ?></button>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+    add_action( 'wp_nav_menu_item_custom_fields', 'poetheme_menu_item_custom_fields', 10, 4 );
+}
+
+if ( ! function_exists( 'poetheme_save_menu_item_meta' ) ) {
+    /**
+     * Save custom nav menu item meta.
+     *
+     * @param int   $menu_id         The menu ID.
+     * @param int   $menu_item_db_id The menu item ID.
+     */
+    function poetheme_save_menu_item_meta( $menu_id, $menu_item_db_id ) {
+        $bold_values = isset( $_POST['poetheme_menu_bold'] ) ? wp_unslash( $_POST['poetheme_menu_bold'] ) : array();
+        $icon_values = isset( $_POST['poetheme_menu_icon'] ) ? wp_unslash( $_POST['poetheme_menu_icon'] ) : array();
+
+        $is_bold = isset( $bold_values[ $menu_item_db_id ] ) ? '1' : '';
+
+        if ( $is_bold ) {
+            update_post_meta( $menu_item_db_id, 'poetheme_menu_bold', '1' );
+        } else {
+            delete_post_meta( $menu_item_db_id, 'poetheme_menu_bold' );
+        }
+
+        if ( isset( $icon_values[ $menu_item_db_id ] ) ) {
+            $icon = sanitize_text_field( $icon_values[ $menu_item_db_id ] );
+            if ( $icon ) {
+                update_post_meta( $menu_item_db_id, 'poetheme_menu_icon', $icon );
+            } else {
+                delete_post_meta( $menu_item_db_id, 'poetheme_menu_icon' );
+            }
+        } else {
+            delete_post_meta( $menu_item_db_id, 'poetheme_menu_icon' );
+        }
+    }
+    add_action( 'wp_update_nav_menu_item', 'poetheme_save_menu_item_meta', 10, 2 );
+}
+
+if ( ! function_exists( 'poetheme_get_lucide_icon_groups' ) ) {
+    /**
+     * Returns grouped Lucide icons for the picker UI.
+     *
+     * @return array
+     */
+    function poetheme_get_lucide_icon_groups() {
+        return array(
+            array(
+                'label' => __( 'Interfaccia', 'poetheme' ),
+                'icons' => array( 'home', 'menu', 'settings', 'search', 'star', 'heart', 'bell', 'bookmark', 'check', 'x', 'chevron-down', 'chevron-right', 'circle', 'square' ),
+            ),
+            array(
+                'label' => __( 'Contenuti', 'poetheme' ),
+                'icons' => array( 'file', 'folder', 'image', 'film', 'music', 'book', 'camera', 'layout-dashboard', 'list', 'grid', 'align-left', 'type' ),
+            ),
+            array(
+                'label' => __( 'Comunicazione', 'poetheme' ),
+                'icons' => array( 'mail', 'phone', 'message-circle', 'message-square', 'send', 'share-2', 'users', 'user', 'user-plus', 'user-check' ),
+            ),
+            array(
+                'label' => __( 'E-commerce', 'poetheme' ),
+                'icons' => array( 'shopping-cart', 'shopping-bag', 'credit-card', 'wallet', 'tag', 'gift', 'percent', 'package' ),
+            ),
+            array(
+                'label' => __( 'Varie', 'poetheme' ),
+                'icons' => array( 'globe', 'map-pin', 'sun', 'moon', 'cloud', 'umbrella', 'coffee', 'leaf', 'sparkles', 'shield', 'rocket' ),
+            ),
+        );
+    }
+}
+
+if ( ! function_exists( 'poetheme_admin_menu_assets' ) ) {
+    /**
+     * Enqueue assets for the nav menu admin screen.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    function poetheme_admin_menu_assets( $hook ) {
+        if ( 'nav-menus.php' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style( 'poetheme-menu-icons', POETHEME_URI . '/assets/css/menu-icons.css', array(), POETHEME_VERSION );
+        wp_enqueue_script( 'poetheme-menu-icons', POETHEME_URI . '/assets/js/menu-icons.js', array( 'jquery' ), POETHEME_VERSION, true );
+        wp_enqueue_script( 'poetheme-lucide-admin', 'https://unpkg.com/lucide@latest/dist/umd/lucide.min.js', array(), POETHEME_VERSION, true );
+
+        wp_localize_script(
+            'poetheme-menu-icons',
+            'poethemeMenuIcons',
+            array(
+                'groups'        => poetheme_get_lucide_icon_groups(),
+                'searchLabel'   => __( 'Cerca tra le icone...', 'poetheme' ),
+                'noResults'     => __( 'Nessuna icona corrisponde ai criteri di ricerca.', 'poetheme' ),
+                'closeLabel'    => __( 'Chiudi', 'poetheme' ),
+                'selectLabel'   => __( "Seleziona un'icona", 'poetheme' ),
+                'allLabel'      => __( 'Tutte', 'poetheme' ),
+            )
+        );
+    }
+    add_action( 'admin_enqueue_scripts', 'poetheme_admin_menu_assets' );
+}

--- a/template-parts/header/style-1.php
+++ b/template-parts/header/style-1.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav class="text-gray-300" aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-4 text-sm',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -114,13 +113,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
 
                 <nav class="nav-primary hidden md:flex flex-1 items-center justify-center gap-6 text-sm font-medium text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                     <?php
-                    wp_nav_menu(
+                    poetheme_render_navigation_menu(
+                        'primary',
+                        'desktop',
                         array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex flex-wrap items-center gap-6 text-sm font-medium',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
+                            'menu_class'  => 'flex flex-wrap items-center gap-6 text-sm font-medium',
+                            'fallback_cb' => 'wp_page_menu',
                         )
                     );
                     ?>
@@ -141,12 +139,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-4 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-3 text-base font-medium text-gray-800',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-3 text-base font-medium text-gray-800',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-2.php
+++ b/template-parts/header/style-2.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav class="text-blue-100" aria-label="<?php esc_attr_e( 'Link rapidi', 'poetheme' ); ?>">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -114,13 +113,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
 
                 <nav class="nav-primary hidden md:flex items-center justify-center gap-8 text-base font-semibold text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                     <?php
-                    wp_nav_menu(
+                    poetheme_render_navigation_menu(
+                        'primary',
+                        'desktop',
                         array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex items-center gap-8 text-base font-semibold tracking-tight',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
+                            'menu_class'  => 'flex items-center gap-8 text-base font-semibold tracking-tight',
+                            'fallback_cb' => 'wp_page_menu',
                         )
                     );
                     ?>
@@ -141,12 +139,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-semibold text-gray-800',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-semibold text-gray-800',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-3.php
+++ b/template-parts/header/style-3.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav aria-label="<?php esc_attr_e( 'Link info', 'poetheme' ); ?>" class="uppercase tracking-[0.2em] text-gray-500">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-xs',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-4 text-xs',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -113,13 +112,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
 
             <nav class="nav-primary hidden md:flex items-center gap-10 text-xs font-semibold tracking-[0.35em] text-gray-700 uppercase" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'desktop',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex items-center gap-10 text-xs font-semibold tracking-[0.35em] uppercase',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
-                        'depth'          => 3,
+                        'menu_class'  => 'flex items-center gap-10 text-xs font-semibold tracking-[0.35em] uppercase',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>
@@ -139,12 +137,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-4 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-3 text-sm font-medium text-gray-800 uppercase tracking-[0.2em]',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-3 text-sm font-medium text-gray-800 uppercase tracking-[0.2em]',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-4.php
+++ b/template-parts/header/style-4.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav aria-label="<?php esc_attr_e( 'Link utili', 'poetheme' ); ?>" class="text-indigo-100">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-4 text-sm uppercase',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -114,13 +113,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
 
                 <nav class="nav-primary hidden lg:flex flex-1 items-center justify-center gap-8 text-sm font-medium" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                     <?php
-                    wp_nav_menu(
+                    poetheme_render_navigation_menu(
+                        'primary',
+                        'desktop',
                         array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex flex-wrap items-center gap-8 text-sm font-medium uppercase tracking-wide',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
+                            'menu_class'  => 'flex flex-wrap items-center gap-8 text-sm font-medium uppercase tracking-wide',
+                            'fallback_cb' => 'wp_page_menu',
                         )
                     );
                     ?>
@@ -141,12 +139,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-5.php
+++ b/template-parts/header/style-5.php
@@ -72,13 +72,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                         <?php if ( $has_top_menu ) : ?>
                             <nav aria-label="<?php esc_attr_e( 'Link rapidi', 'poetheme' ); ?>" class="text-indigo-100">
                                 <?php
-                                wp_nav_menu(
+                                poetheme_render_navigation_menu(
+                                    'top-info',
+                                    'desktop',
                                     array(
-                                        'theme_location' => 'top-info',
-                                        'menu_class'     => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
-                                        'container'      => false,
-                                        'depth'          => 1,
-                                        'fallback_cb'    => false,
+                                        'menu_class'  => 'flex flex-wrap items-center gap-4 text-sm uppercase tracking-wide',
+                                        'fallback_cb' => false,
                                     )
                                 );
                                 ?>
@@ -119,13 +118,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
 
                 <nav class="nav-primary hidden lg:flex items-center gap-10 text-base font-medium" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                     <?php
-                    wp_nav_menu(
+                    poetheme_render_navigation_menu(
+                        'primary',
+                        'desktop',
                         array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex items-center gap-10 text-base font-medium uppercase tracking-wide',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
+                            'menu_class'  => 'flex items-center gap-10 text-base font-medium uppercase tracking-wide',
+                            'fallback_cb' => 'wp_page_menu',
                         )
                     );
                     ?>
@@ -172,12 +170,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-6.php
+++ b/template-parts/header/style-6.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav aria-label="<?php esc_attr_e( 'Informazioni', 'poetheme' ); ?>" class="text-rose-100">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -113,17 +112,16 @@ $has_top_menu = has_nav_menu( 'top-info' );
                 </div>
 
                 <nav class="nav-primary hidden md:flex items-center gap-8 text-sm font-semibold text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
-                    <?php
-                    wp_nav_menu(
-                        array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex items-center gap-8 text-sm font-semibold uppercase tracking-wide',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
-                        )
-                    );
-                    ?>
+                <?php
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'desktop',
+                    array(
+                        'menu_class'  => 'flex items-center gap-8 text-sm font-semibold uppercase tracking-wide',
+                        'fallback_cb' => 'wp_page_menu',
+                    )
+                );
+                ?>
                 </nav>
 
                 <?php if ( '' !== $cta_text ) : ?>
@@ -141,12 +139,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-800',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-medium text-gray-800',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-7.php
+++ b/template-parts/header/style-7.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav aria-label="<?php esc_attr_e( 'Menu informazioni', 'poetheme' ); ?>" class="text-gray-300">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -126,17 +125,16 @@ $has_top_menu = has_nav_menu( 'top-info' );
                 </div>
 
                 <nav class="nav-primary hidden md:flex items-center gap-6 text-sm font-medium text-gray-700" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
-                    <?php
-                    wp_nav_menu(
-                        array(
-                            'theme_location' => 'primary',
-                            'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
-                            'container'      => false,
-                            'fallback_cb'    => 'wp_page_menu',
-                            'depth'          => 3,
-                        )
-                    );
-                    ?>
+                <?php
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'desktop',
+                    array(
+                        'menu_class'  => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
+                        'fallback_cb' => 'wp_page_menu',
+                    )
+                );
+                ?>
                 </nav>
 
                 <div class="hidden md:flex items-center gap-3">
@@ -162,12 +160,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>

--- a/template-parts/header/style-8.php
+++ b/template-parts/header/style-8.php
@@ -68,13 +68,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
                     <?php if ( $has_top_menu ) : ?>
                         <nav aria-label="<?php esc_attr_e( 'Supporto rapido', 'poetheme' ); ?>" class="text-indigo-100">
                             <?php
-                            wp_nav_menu(
+                            poetheme_render_navigation_menu(
+                                'top-info',
+                                'desktop',
                                 array(
-                                    'theme_location' => 'top-info',
-                                    'menu_class'     => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
-                                    'container'      => false,
-                                    'depth'          => 1,
-                                    'fallback_cb'    => false,
+                                    'menu_class'  => 'flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide',
+                                    'fallback_cb' => false,
                                 )
                             );
                             ?>
@@ -147,13 +146,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <nav class="nav-primary flex items-center gap-6 text-sm font-medium text-gray-700 py-3" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'desktop',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
-                        'depth'          => 3,
+                        'menu_class'  => 'flex items-center gap-6 text-sm font-medium uppercase tracking-wide',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>
@@ -177,12 +175,12 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="px-4 py-5 space-y-4" @click.away="mobileOpen = false">
             <nav aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
-                wp_nav_menu(
+                poetheme_render_navigation_menu(
+                    'primary',
+                    'mobile',
                     array(
-                        'theme_location' => 'primary',
-                        'menu_class'     => 'flex flex-col gap-4 text-base font-medium text-gray-900',
-                        'container'      => false,
-                        'fallback_cb'    => 'wp_page_menu',
+                        'menu_class'  => 'flex flex-col gap-4 text-base font-medium text-gray-900',
+                        'fallback_cb' => 'wp_page_menu',
                     )
                 );
                 ?>


### PR DESCRIPTION
## Summary
- add a dedicated navigation walker that supports multi-level dropdowns for the primary and top info menus
- expose menu item options in the admin to toggle bold text and select a Lucide icon via a searchable picker
- update header templates to use the new helper for desktop and mobile menus and load supporting assets

## Testing
- php -l inc/nav-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68e1207d8c70833288ffcae35560e237