### PR TITLE
Implement interactive navigation handling for theme menus

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,141 @@
+(function () {
+    'use strict';
+
+    function initNavigation() {
+        var menus = document.querySelectorAll('[data-poetheme-nav="1"]');
+        if (!menus.length) {
+            return;
+        }
+
+        menus.forEach(function (menu) {
+            var variant = menu.getAttribute('data-variant') || 'desktop';
+            if (variant === 'mobile') {
+                setupMobileMenu(menu);
+            } else {
+                setupDesktopMenu(menu);
+            }
+        });
+    }
+
+    function setupDesktopMenu(menu) {
+        var items = menu.querySelectorAll('li.menu-item-has-children');
+        if (!items.length) {
+            return;
+        }
+
+        items.forEach(function (item) {
+            var trigger = item.querySelector(':scope > a[data-poetheme-toggle="submenu"]');
+            var submenu = item.querySelector(':scope > [data-poetheme-submenu="true"]');
+            if (!submenu) {
+                return;
+            }
+
+            var closeTimer = null;
+
+            var openMenu = function () {
+                if (closeTimer) {
+                    clearTimeout(closeTimer);
+                    closeTimer = null;
+                }
+
+                item.classList.add('is-open');
+                submenu.classList.remove('hidden');
+                submenu.classList.add('block');
+                if (trigger) {
+                    trigger.setAttribute('aria-expanded', 'true');
+                }
+            };
+
+            var scheduleClose = function () {
+                if (closeTimer) {
+                    clearTimeout(closeTimer);
+                }
+
+                closeTimer = setTimeout(function () {
+                    item.classList.remove('is-open');
+                    submenu.classList.remove('block');
+                    submenu.classList.add('hidden');
+                    if (trigger) {
+                        trigger.setAttribute('aria-expanded', 'false');
+                    }
+                    closeTimer = null;
+                }, 200);
+            };
+
+            var cancelClose = function () {
+                if (closeTimer) {
+                    clearTimeout(closeTimer);
+                    closeTimer = null;
+                }
+            };
+
+            item.addEventListener('mouseenter', openMenu);
+            item.addEventListener('mouseleave', scheduleClose);
+
+            item.addEventListener('focusin', function () {
+                cancelClose();
+                openMenu();
+            });
+
+            item.addEventListener('focusout', function (event) {
+                if (event.relatedTarget && item.contains(event.relatedTarget)) {
+                    return;
+                }
+                scheduleClose();
+            });
+
+            submenu.addEventListener('mouseenter', cancelClose);
+            submenu.addEventListener('mouseleave', scheduleClose);
+        });
+    }
+
+    function setupMobileMenu(menu) {
+        var items = menu.querySelectorAll('li.menu-item-has-children');
+        if (!items.length) {
+            return;
+        }
+
+        items.forEach(function (item) {
+            var trigger = item.querySelector(':scope > a[data-poetheme-toggle="submenu"]');
+            var submenu = item.querySelector(':scope > [data-poetheme-submenu="true"]');
+            if (!trigger || !submenu) {
+                return;
+            }
+
+            var openItem = function () {
+                item.classList.add('is-open');
+                trigger.setAttribute('aria-expanded', 'true');
+                submenu.setAttribute('aria-hidden', 'false');
+            };
+
+            var closeItem = function () {
+                item.classList.remove('is-open');
+                trigger.setAttribute('aria-expanded', 'false');
+                submenu.setAttribute('aria-hidden', 'true');
+            };
+
+            if (item.classList.contains('current-menu-ancestor') || item.classList.contains('current-menu-item')) {
+                openItem();
+            } else {
+                closeItem();
+            }
+
+            trigger.addEventListener('click', function (event) {
+                event.preventDefault();
+                if (item.classList.contains('is-open')) {
+                    closeItem();
+                } else {
+                    openItem();
+                }
+            });
+        });
+
+        menu.setAttribute('data-ready', 'true');
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initNavigation);
+    } else {
+        initNavigation();
+    }
+})();

--- a/functions.php
+++ b/functions.php
@@ -122,6 +122,8 @@ function poetheme_scripts() {
         'document.addEventListener("DOMContentLoaded",function(){if(window.lucide){window.lucide.createIcons();}});'
     );
 
+    wp_enqueue_script( 'poetheme-navigation', POETHEME_URI . '/assets/js/navigation.js', array(), POETHEME_VERSION, true );
+    wp_script_add_data( 'poetheme-navigation', 'defer', true );
 }
 add_action( 'wp_enqueue_scripts', 'poetheme_scripts' );
 

--- a/style.css
+++ b/style.css
@@ -116,3 +116,33 @@ body.rtl .skip-link {
   right: 0;
 }
 
+.poetheme-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.poetheme-nav--desktop li.is-open > [data-poetheme-submenu="true"] {
+  display: block;
+}
+
+.poetheme-nav--desktop [data-poetheme-submenu="true"] {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.poetheme-nav--mobile[data-ready="true"] [data-poetheme-submenu="true"] {
+  display: none;
+}
+
+.poetheme-nav--mobile[data-ready="true"] li.is-open > [data-poetheme-submenu="true"] {
+  display: block;
+}
+
+.poetheme-nav--mobile .poetheme-submenu-indicator {
+  transition: transform 0.2s ease;
+}
+
+.poetheme-nav--mobile li.is-open .poetheme-submenu-indicator {
+  transform: rotate(180deg);
+}
+


### PR DESCRIPTION
## Summary
- enhance the custom navigation walker to expose submenu IDs, aria attributes, and utility classes required for interactive dropdowns while preserving icon and bold metadata
- append shared navigation classes through the rendering helper and add a front-end controller script plus supporting styles for desktop hover and mobile toggle behavior
- load the new navigation script in the theme so mobile submenus collapse/expand with accessibility states similar to the provided Alpine.js example

## Testing
- php -l inc/nav-menu.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e126d1a4d88332b8483b50ef675447