### PR TITLE
Ensure navigation menus display all assigned items

### DIFF
--- a/inc/nav-menu.php
+++ b/inc/nav-menu.php
@@ -348,7 +348,7 @@ if ( ! function_exists( 'poetheme_render_navigation_menu' ) ) {
         $defaults = array(
             'theme_location' => $location,
             'container'      => false,
-            'depth'          => 3,
+            'depth'          => 0,
             'items_wrap'     => '<ul id="%1$s" class="%2$s" data-poetheme-nav="1" data-variant="' . esc_attr( $variant ) . '" data-location="' . esc_attr( $location ) . '">%3$s</ul>',
         );
 
@@ -365,7 +365,7 @@ if ( ! function_exists( 'poetheme_render_navigation_menu' ) ) {
         $defaults['walker']   = new PoeTheme_Nav_Walker( $walker_args );
 
         if ( 'mobile' === $variant ) {
-            $defaults['depth'] = 3;
+            $defaults['depth'] = 0;
         }
 
         $args = wp_parse_args( $args, $defaults );


### PR DESCRIPTION
## Summary
- remove the depth limitation from the theme navigation helper so all assigned menu items render on desktop and mobile
- apply the unlimited depth configuration to the custom walker to keep nested items available across variants

## Testing
- php -l inc/nav-menu.php

------
https://chatgpt.com/codex/tasks/task_e_68e23bdd4bd88332b3a3d663f8174aac