### PR TITLE
Gerarchia tipografica H1–H6 e aggiornamento versione a 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.3
+- Introdotta gerarchia tipografica default per heading H1–H6 frontend/editor.
+
 ## 1.8.2
 - Migliorata la UI admin delle opzioni tema con layout a pannelli, spacing coerente e supporto responsive.
 - Rafforzata l’accessibilità dei form admin con label e descrizioni collegate tramite `aria-describedby`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'edi
 
 **Stato del tema:** Core Stable (release-ready).
 
+## Changelog
+- 1.8.3: introdotta gerarchia tipografica default per heading H1–H6 frontend/editor.
+
 ## Milestone completate (M1–M8)
 - M1–M3: architettura modulare e sicurezza.
 - M4: design system base con `theme.json`.

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -5,6 +5,58 @@ body.block-editor-page .editor-styles-wrapper {
   background-color: var(--wp--preset--color--background);
 }
 
+/* Base typography: headings */
+body.block-editor-page .editor-styles-wrapper :where(h1, h2, h3, h4, h5, h6) {
+  font-family: inherit;
+  text-wrap: balance;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h1):not([class*="-font-size"]) {
+  font-size: clamp(2.25rem, 4vw, 3.75rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h2):not([class*="-font-size"]) {
+  font-size: clamp(1.875rem, 3vw, 3rem);
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h3):not([class*="-font-size"]) {
+  font-size: clamp(1.5rem, 2.2vw, 2.25rem);
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h4):not([class*="-font-size"]) {
+  font-size: clamp(1.25rem, 1.8vw, 1.75rem);
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h5):not([class*="-font-size"]) {
+  font-size: clamp(1.125rem, 1.4vw, 1.375rem);
+  line-height: 1.35;
+  font-weight: 600;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(h6):not([class*="-font-size"]) {
+  font-size: clamp(1rem, 1.2vw, 1.125rem);
+  line-height: 1.4;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+body.block-editor-page .editor-styles-wrapper :where(.wp-block-heading) {
+  margin-top: 1.5em;
+  margin-bottom: 0.6em;
+}
+
+body.block-editor-page .editor-styles-wrapper > :where(.wp-block-heading):first-child {
+  margin-top: 0;
+}
+
 body.block-editor-page .editor-styles-wrapper a {
   color: var(--wp--preset--color--primary);
 }

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.8.1' );
+define( 'POETHEME_VERSION', '1.8.3' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.8.2
+Version: 1.8.3
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -232,9 +232,94 @@ article {
   padding: 1.5rem 0;
 }
 
-article header h1,
-article header h2 {
-  font-size: 1.875rem;
+/* Base typography: headings */
+:where(h1, h2, h3, h4, h5, h6) {
+  font-family: inherit;
+  text-wrap: balance;
+}
+
+:where(h1):not([class*="-font-size"]),
+:where(main h1):not([class*="-font-size"]),
+:where(.entry-content h1):not([class*="-font-size"]),
+:where(h1.wp-block-heading):not([class*="-font-size"]),
+.poetheme-page-title,
+.poetheme-post-title,
+.poetheme-category-title {
+  font-size: clamp(2.25rem, 4vw, 3.75rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+:where(h2):not([class*="-font-size"]),
+:where(main h2):not([class*="-font-size"]),
+:where(.entry-content h2):not([class*="-font-size"]),
+:where(h2.wp-block-heading):not([class*="-font-size"]) {
+  font-size: clamp(1.875rem, 3vw, 3rem);
+  line-height: 1.15;
+  font-weight: 700;
+}
+
+:where(h3):not([class*="-font-size"]),
+:where(main h3):not([class*="-font-size"]),
+:where(.entry-content h3):not([class*="-font-size"]),
+:where(h3.wp-block-heading):not([class*="-font-size"]) {
+  font-size: clamp(1.5rem, 2.2vw, 2.25rem);
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+:where(h4):not([class*="-font-size"]),
+:where(main h4):not([class*="-font-size"]),
+:where(.entry-content h4):not([class*="-font-size"]),
+:where(h4.wp-block-heading):not([class*="-font-size"]) {
+  font-size: clamp(1.25rem, 1.8vw, 1.75rem);
+  line-height: 1.25;
+  font-weight: 600;
+}
+
+:where(h5):not([class*="-font-size"]),
+:where(main h5):not([class*="-font-size"]),
+:where(.entry-content h5):not([class*="-font-size"]),
+:where(h5.wp-block-heading):not([class*="-font-size"]) {
+  font-size: clamp(1.125rem, 1.4vw, 1.375rem);
+  line-height: 1.35;
+  font-weight: 600;
+}
+
+:where(h6):not([class*="-font-size"]),
+:where(main h6):not([class*="-font-size"]),
+:where(.entry-content h6):not([class*="-font-size"]),
+:where(h6.wp-block-heading):not([class*="-font-size"]) {
+  font-size: clamp(1rem, 1.2vw, 1.125rem);
+  line-height: 1.4;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+:where(.entry-content, main) :where(h1, h2, h3, h4, h5, h6, .wp-block-heading) {
+  margin-top: 1.5em;
+  margin-bottom: 0.6em;
+}
+
+:where(.entry-content, main) > :where(h1, h2, h3, h4, h5, h6, .wp-block-heading):first-child {
+  margin-top: 0;
+}
+
+:where(header, nav, aside, footer) :where(h1, h2, h3, h4, h5, h6):not(.wp-block-heading) {
+  margin-top: 0;
+}
+
+.poetheme-post-title {
+  font-size: clamp(1.5rem, 2.2vw, 2.25rem);
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+h1.poetheme-post-title,
+h1.poetheme-page-title,
+h1.poetheme-category-title {
+  font-size: clamp(2.25rem, 4vw, 3.75rem);
+  line-height: 1.1;
   font-weight: 700;
 }
 

--- a/theme.json
+++ b/theme.json
@@ -155,7 +155,14 @@
           "size": "4rem"
         }
       ],
-      "units": [ "px", "rem", "em", "%", "vw", "vh" ],
+      "units": [
+        "px",
+        "rem",
+        "em",
+        "%",
+        "vw",
+        "vh"
+      ],
       "customSpacingSize": true
     },
     "layout": {
@@ -177,6 +184,49 @@
       "link": {
         "color": {
           "text": "var:preset|color|primary"
+        }
+      },
+      "h1": {
+        "typography": {
+          "fontSize": "clamp(2.25rem, 4vw, 3.75rem)",
+          "lineHeight": "1.1",
+          "fontWeight": "700"
+        }
+      },
+      "h2": {
+        "typography": {
+          "fontSize": "clamp(1.875rem, 3vw, 3rem)",
+          "lineHeight": "1.15",
+          "fontWeight": "700"
+        }
+      },
+      "h3": {
+        "typography": {
+          "fontSize": "clamp(1.5rem, 2.2vw, 2.25rem)",
+          "lineHeight": "1.2",
+          "fontWeight": "600"
+        }
+      },
+      "h4": {
+        "typography": {
+          "fontSize": "clamp(1.25rem, 1.8vw, 1.75rem)",
+          "lineHeight": "1.25",
+          "fontWeight": "600"
+        }
+      },
+      "h5": {
+        "typography": {
+          "fontSize": "clamp(1.125rem, 1.4vw, 1.375rem)",
+          "lineHeight": "1.35",
+          "fontWeight": "600"
+        }
+      },
+      "h6": {
+        "typography": {
+          "fontSize": "clamp(1rem, 1.2vw, 1.125rem)",
+          "lineHeight": "1.4",
+          "fontWeight": "600",
+          "letterSpacing": "0.02em"
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Gli heading H1–H6 risultavano visivamente troppo simili al testo normale e la gerarchia tipografica non era definita in modo chiaro nel tema. 
- Il design system usa `theme.json` ma non conteneva stili granulari per ogni heading, e l'unica regola CSS esistente (`article header h1/h2`) appiattiva la gerarchia. 
- Occorreva allineare frontend ed editor Gutenberg senza sovrascrivere le classi `.has-*-font-size` già generate dall'editor e senza toccare la logica dinamica dei colori in `inc/head-output.php`.

### Description
- Aggiunti stili tipografici per `h1`…`h6` in `theme.json` sotto `styles.elements` con `fontSize`, `lineHeight`, `fontWeight` e `letterSpacing` per `h6` usando valori responsive `clamp()` dove indicato. 
- Sostituita la regola parziale `article header h1/h2` con una sezione dedicata in `style.css` (`/* Base typography: headings */`) che definisce gerarchia, `line-height`, `font-weight`, `margin` verticale e selettori che evitano di sovrascrivere le classi di dimensione di Gutenberg (`:not([class*="-font-size"])`). 
- Aggiunte regole specifiche per `.poetheme-post-title`, `.poetheme-page-title` e `.poetheme-category-title` per mantenere una gerarchia chiara delle title classes usate nei template. 
- Allineati gli stili nell'editor aggiungendo regole equivalenti in `assets/css/editor.css` all'interno di `.editor-styles-wrapper` garantendo che le dimensioni manuali impostate dall'utente non vengano sovrascritte. 
- Aggiornata la versione del tema a `1.8.3` in `style.css` e `POETHEME_VERSION` in `functions.php`, e documentata la release in `README.md` e `CHANGELOG.md`.

### Testing
- Eseguito `python3 -m json.tool theme.json` per validare il JSON di `theme.json` e il controllo è andato a buon fine. 
- Eseguito `php -l functions.php` e il controllo di sintassi PHP su tutti i file `.php` tramite `find ... | xargs php -l`, senza errori di sintassi rilevati. 
- Eseguito `git diff --check` e non sono stati trovati errori di diff/whitespace. 
- Tutti i controlli automatici sopra descritti sono passati con esito positivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a293454a8cc8332b58b86b7e88aa055)