### PR TITLE
Add Style 9 “App Sidebar” header layout with collapsible sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'edi
 **Stato del tema:** Core Stable (release-ready).
 
 ## Changelog
+- 1.8.4: aggiunto header layout **Style 9 – App Sidebar** con sidebar verticale collassabile, topbar contenuto con titolo/breadcrumb e profilo sito/autore.
 - 1.8.3: introdotta gerarchia tipografica default per heading H1–H6 frontend/editor.
 
 ## Milestone completate (M1–M8)
@@ -23,6 +24,7 @@ Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'edi
 - Compatibile con RTL, traduzioni tramite file POT e widget-ready (sidebar e footer).
 - Opzioni tema dedicate (Generale e Logo) per personalizzare tagline, breadcrumb e branding.
 - UI admin delle opzioni migliorata con form più leggibili, coerenti e responsive.
+- Nuovo header **Style 9 – App Sidebar**, pensato per siti editoriali, dashboard-like, documentazioni, portali e progetti con navigazione laterale persistente.
 
 ## SEO & Schema Policy
 Il tema gestisce un set minimo di dati strutturati JSON-LD e breadcrumb HTML in modo compatibile con i plugin SEO più diffusi.
@@ -97,6 +99,7 @@ Obiettivo: garantire la conformità a livello di tema (struttura, navigazione, f
 - Style 6 (Stack | Center): nessuna modifica (layout conforme).
 - Style 7 (Stack | Left): nessuna modifica (layout conforme).
 - Style 8 (Plain): nessuna modifica (layout conforme).
+- Style 9 (App Sidebar): sidebar verticale collassabile con logo in alto, menu laterale, titolo pagina e breadcrumb nell’area contenuto, profilo sito/autore in basso.
 
 ## Asset Policy (M5)
 - Preferire asset locali e versionati.
@@ -109,7 +112,8 @@ Obiettivo: garantire la conformità a livello di tema (struttura, navigazione, f
 - `poetheme-style` (`style.css`)
 
 **Frontend scripts**
-- `poetheme-navigation` (`assets/js/navigation.js`, solo se è presente un menu primario)
+- `poetheme-navigation` (`assets/js/navigation.js`, solo se è presente un menu primario o il layout App Sidebar)
+- `poetheme-app-sidebar` (`assets/js/app-sidebar.js`, solo con header Style 9 – App Sidebar)
 - `poetheme-alpine` (CDN, Alpine.js 3.13.5, interazioni header)
 - `poetheme-lucide` (CDN, Lucide 0.294.0, icone frontend)
 - `poetheme-media-lightbox` (`assets/js/media-lightbox.js`, solo se opzione abilitata e pagina singola/home)

--- a/assets/css/admin-header-layouts.css
+++ b/assets/css/admin-header-layouts.css
@@ -63,3 +63,85 @@
         grid-template-columns: minmax(0, 1fr);
     }
 }
+
+.poetheme-header-layout__description {
+    color: #646970;
+    display: block;
+    font-size: 12px;
+    line-height: 1.35;
+    max-width: 100%;
+}
+
+.poetheme-header-layout__preview {
+    background: #f8fafc;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    display: grid;
+    height: 118px;
+    overflow: hidden;
+    width: 100%;
+}
+
+.poetheme-header-layout__preview--app-sidebar {
+    grid-template-columns: 32% 1fr;
+}
+
+.poetheme-header-layout__preview-sidebar {
+    background: #f1f1f1;
+    border-right: 1px solid #dcdcde;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 8px;
+}
+
+.poetheme-header-layout__preview-sidebar span {
+    background: #8c8f94;
+    border-radius: 999px;
+    display: block;
+    height: 6px;
+    opacity: 0.9;
+}
+
+.poetheme-header-layout__preview-sidebar span:first-child {
+    background: #1d2327;
+    height: 12px;
+    margin-bottom: 8px;
+    width: 70%;
+}
+
+.poetheme-header-layout__preview-sidebar span:last-child {
+    margin-top: auto;
+    width: 42%;
+}
+
+.poetheme-header-layout__preview-main {
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+}
+
+.poetheme-header-layout__preview-main span {
+    background: #dcdcde;
+    border-radius: 999px;
+    display: block;
+    height: 8px;
+}
+
+.poetheme-header-layout__preview-main span:first-child {
+    background: #1d2327;
+    height: 18px;
+    width: 68%;
+}
+
+.poetheme-header-layout__preview-main span:nth-child(2) {
+    margin-left: auto;
+    width: 44%;
+}
+
+.poetheme-header-layout__preview-main span:last-child {
+    height: 42px;
+    width: 84%;
+}

--- a/assets/js/app-sidebar.js
+++ b/assets/js/app-sidebar.js
@@ -1,0 +1,55 @@
+(function () {
+    'use strict';
+
+    var storageKey = 'poethemeAppSidebarCollapsed';
+
+    function getStoredState() {
+        try {
+            return window.localStorage.getItem(storageKey) === '1';
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function setStoredState(isCollapsed) {
+        try {
+            window.localStorage.setItem(storageKey, isCollapsed ? '1' : '0');
+        } catch (error) {}
+    }
+
+    function updateShell(shell, toggle, isCollapsed) {
+        var label = toggle ? toggle.querySelector('[data-poetheme-app-sidebar-toggle-label]') : null;
+
+        shell.classList.toggle('is-sidebar-collapsed', isCollapsed);
+        shell.classList.toggle('poetheme-app-shell--sidebar-expanded', !isCollapsed);
+
+        if (toggle) {
+            toggle.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
+            toggle.setAttribute(
+                'aria-label',
+                isCollapsed ? poethemeAppSidebar.expandLabel : poethemeAppSidebar.collapseLabel
+            );
+        }
+
+        if (label) {
+            label.textContent = isCollapsed ? poethemeAppSidebar.expandLabel : poethemeAppSidebar.collapseLabel;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var shell = document.querySelector('[data-poetheme-app-shell]');
+        var toggle = document.querySelector('[data-poetheme-app-sidebar-toggle]');
+
+        if (!shell || !toggle || typeof poethemeAppSidebar === 'undefined') {
+            return;
+        }
+
+        updateShell(shell, toggle, getStoredState());
+
+        toggle.addEventListener('click', function () {
+            var isCollapsed = !shell.classList.contains('is-sidebar-collapsed');
+            updateShell(shell, toggle, isCollapsed);
+            setStoredState(isCollapsed);
+        });
+    });
+}());

--- a/footer.php
+++ b/footer.php
@@ -114,6 +114,14 @@
     <?php endif; ?>
     <?php endif; ?>
 
+    <?php
+    $current_header_layout = isset( $GLOBALS['poetheme_current_header_layout'] ) ? $GLOBALS['poetheme_current_header_layout'] : '';
+    if ( 'style-9' === $current_header_layout ) :
+    ?>
+        </div><!-- .poetheme-app-main -->
+    </div><!-- .poetheme-app-shell -->
+    <?php endif; ?>
+
     <?php wp_footer(); ?>
 </body>
 </html>

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.8.3' );
+define( 'POETHEME_VERSION', '1.8.4' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/header.php
+++ b/header.php
@@ -20,11 +20,17 @@ $layout         = isset( $header_context['layout'] ) ? $header_context['layout']
 $template_slug  = 'template-parts/header/' . $layout;
 
 if ( ! locate_template( array( $template_slug . '.php' ), false, false ) ) {
-    $template_slug = 'template-parts/header/style-1';
+    $layout                    = 'style-1';
+    $header_context['layout']  = $layout;
+    $template_slug             = 'template-parts/header/style-1';
 }
+
+$GLOBALS['poetheme_current_header_layout'] = $layout;
 
 get_template_part( $template_slug, null, $header_context );
 ?>
 
 <main id="primary-content" class="<?php echo esc_attr( poetheme_get_main_classes() ); ?>" tabindex="-1">
-    <?php poetheme_render_subheader(); ?>
+    <?php if ( 'style-9' !== $layout ) : ?>
+        <?php poetheme_render_subheader(); ?>
+    <?php endif; ?>

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -38,6 +38,63 @@ function poetheme_get_header_social_networks() {
     );
 }
 
+
+/**
+ * Retrieve the available header layout choices.
+ *
+ * @return array
+ */
+function poetheme_get_header_layout_choices() {
+    return array(
+        'style-1' => array(
+            'label'       => __( 'Classic', 'poetheme' ),
+            'description' => __( 'Layout classico con logo, navigazione e opzioni top bar.', 'poetheme' ),
+            'image'       => 'classic.png',
+        ),
+        'style-2' => array(
+            'label'       => __( 'Split menu | Semitransparent', 'poetheme' ),
+            'description' => __( 'Layout con menu diviso e testata semitrasparente.', 'poetheme' ),
+            'image'       => 'split-menu-semitransparent.png',
+        ),
+        'style-3' => array(
+            'label'       => __( 'Shop split', 'poetheme' ),
+            'description' => __( 'Layout shop con navigazione divisa.', 'poetheme' ),
+            'image'       => 'shop-split.png',
+        ),
+        'style-4' => array(
+            'label'       => __( 'Shop', 'poetheme' ),
+            'description' => __( 'Layout shop compatto con azioni in testata.', 'poetheme' ),
+            'image'       => 'shop.png',
+        ),
+        'style-5' => array(
+            'label'       => __( 'Fixed', 'poetheme' ),
+            'description' => __( 'Layout con testata fissa.', 'poetheme' ),
+            'image'       => 'fixed.png',
+        ),
+        'style-6' => array(
+            'label'       => __( 'Stack | Center', 'poetheme' ),
+            'description' => __( 'Layout impilato con logo centrato.', 'poetheme' ),
+            'image'       => 'stack-center.png',
+        ),
+        'style-7' => array(
+            'label'       => __( 'Stack | Left', 'poetheme' ),
+            'description' => __( 'Layout impilato con logo allineato a sinistra.', 'poetheme' ),
+            'image'       => 'stack-left.png',
+        ),
+        'style-8' => array(
+            'label'       => __( 'Plain', 'poetheme' ),
+            'description' => __( 'Layout essenziale e minimale.', 'poetheme' ),
+            'image'       => 'plain.png',
+        ),
+        'style-9' => array(
+            'label'       => __( 'App Sidebar', 'poetheme' ),
+            'description' => __( 'Layout con sidebar verticale collassabile, logo in alto, menu laterale, titolo pagina e breadcrumb nell’area contenuto.', 'poetheme' ),
+            'image'       => '',
+            'preview'     => 'app-sidebar',
+        ),
+    );
+}
+
 /**
  * Default values for header options.
  *
@@ -3559,40 +3616,7 @@ function poetheme_render_logo_page() {
  */
 function poetheme_render_header_page() {
     $options       = poetheme_get_header_options();
-    $layouts       = array(
-        'style-1' => array(
-            'label' => __( 'Classic', 'poetheme' ),
-            'image' => 'classic.png',
-        ),
-        'style-2' => array(
-            'label' => __( 'Split menu | Semitransparent', 'poetheme' ),
-            'image' => 'split-menu-semitransparent.png',
-        ),
-        'style-3' => array(
-            'label' => __( 'Shop split', 'poetheme' ),
-            'image' => 'shop-split.png',
-        ),
-        'style-4' => array(
-            'label' => __( 'Shop', 'poetheme' ),
-            'image' => 'shop.png',
-        ),
-        'style-5' => array(
-            'label' => __( 'Fixed', 'poetheme' ),
-            'image' => 'fixed.png',
-        ),
-        'style-6' => array(
-            'label' => __( 'Stack | Center', 'poetheme' ),
-            'image' => 'stack-center.png',
-        ),
-        'style-7' => array(
-            'label' => __( 'Stack | Left', 'poetheme' ),
-            'image' => 'stack-left.png',
-        ),
-        'style-8' => array(
-            'label' => __( 'Plain', 'poetheme' ),
-            'image' => 'plain.png',
-        ),
-    );
+    $layouts       = poetheme_get_header_layout_choices();
     $socials       = poetheme_get_header_social_networks();
     $show_cta      = ! empty( $options['show_cta'] );
     $top_bar_texts = isset( $options['top_bar_texts'] ) && is_array( $options['top_bar_texts'] ) ? $options['top_bar_texts'] : array();
@@ -3637,12 +3661,26 @@ function poetheme_render_header_page() {
                                                     aria-label="<?php echo esc_attr( $layout['label'] ); ?>"
                                                 />
                                                 <span class="poetheme-header-layout__card">
-                                                    <img
-                                                        src="<?php echo esc_url( POETHEME_URI . '/assets/img/admin/header-layouts/' . $layout['image'] ); ?>"
-                                                        alt="<?php echo esc_attr( $layout['label'] ); ?>"
-                                                        class="poetheme-header-layout__image"
-                                                    />
+                                                    <?php if ( ! empty( $layout['image'] ) ) : ?>
+                                                        <img
+                                                            src="<?php echo esc_url( POETHEME_URI . '/assets/img/admin/header-layouts/' . $layout['image'] ); ?>"
+                                                            alt="<?php echo esc_attr( $layout['label'] ); ?>"
+                                                            class="poetheme-header-layout__image"
+                                                        />
+                                                    <?php else : ?>
+                                                        <span class="poetheme-header-layout__preview poetheme-header-layout__preview--<?php echo esc_attr( isset( $layout['preview'] ) ? sanitize_html_class( $layout['preview'] ) : sanitize_html_class( $layout_key ) ); ?>" aria-hidden="true">
+                                                            <span class="poetheme-header-layout__preview-sidebar">
+                                                                <span></span><span></span><span></span><span></span>
+                                                            </span>
+                                                            <span class="poetheme-header-layout__preview-main">
+                                                                <span></span><span></span><span></span>
+                                                            </span>
+                                                        </span>
+                                                    <?php endif; ?>
                                                     <span class="poetheme-header-layout__name"><?php echo esc_html( $layout['label'] ); ?></span>
+                                                    <?php if ( ! empty( $layout['description'] ) ) : ?>
+                                                        <span class="poetheme-header-layout__description"><?php echo esc_html( $layout['description'] ); ?></span>
+                                                    <?php endif; ?>
                                                 </span>
                                             </label>
                                         <?php endforeach; ?>
@@ -4228,7 +4266,7 @@ function poetheme_sanitize_header_options( $input ) {
 
     if ( isset( $input['layout'] ) ) {
         $layout = sanitize_key( $input['layout'] );
-        if ( preg_match( '/^style-[1-8]$/', $layout ) ) {
+        if ( isset( poetheme_get_header_layout_choices()[ $layout ] ) ) {
             $output['layout'] = $layout;
         }
     }
@@ -4403,7 +4441,7 @@ function poetheme_get_header_options() {
 
     // Validate layout fallback.
     $layout = isset( $options['layout'] ) ? sanitize_key( $options['layout'] ) : $defaults['layout'];
-    if ( ! preg_match( '/^style-[1-8]$/', $layout ) ) {
+    if ( ! isset( poetheme_get_header_layout_choices()[ $layout ] ) ) {
         $layout = $defaults['layout'];
     }
     $options['layout'] = $layout;

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -19,6 +19,7 @@
  * - poetheme-alpine (CDN, Alpine.js 3.13.5)
  * - poetheme-lucide (CDN, Lucide 0.294.0)
  * - poetheme-media-lightbox (assets/js/media-lightbox.js, conditional)
+ * - poetheme-app-sidebar (assets/js/app-sidebar.js, style-9 only)
  *
  * Editor scripts:
  * - poetheme-editor-alpine (CDN, Alpine.js 3.13.5)
@@ -125,7 +126,8 @@ function poetheme_should_load_lucide() {
  * @return bool
  */
 function poetheme_should_load_navigation() {
-    $should_load = has_nav_menu( 'primary' );
+    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
+    $should_load    = has_nav_menu( 'primary' ) || ( isset( $header_options['layout'] ) && 'style-9' === $header_options['layout'] );
 
     return (bool) apply_filters( 'poetheme_should_load_navigation', $should_load );
 }
@@ -280,6 +282,20 @@ function poetheme_scripts() {
     if ( poetheme_should_load_navigation() ) {
         wp_enqueue_script( 'poetheme-navigation', POETHEME_URI . '/assets/js/navigation.js', array(), poetheme_get_asset_version( 'assets/js/navigation.js' ), true );
         wp_script_add_data( 'poetheme-navigation', 'defer', true );
+    }
+
+    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
+    if ( isset( $header_options['layout'] ) && 'style-9' === $header_options['layout'] ) {
+        wp_enqueue_script( 'poetheme-app-sidebar', POETHEME_URI . '/assets/js/app-sidebar.js', array(), poetheme_get_asset_version( 'assets/js/app-sidebar.js' ), true );
+        wp_localize_script(
+            'poetheme-app-sidebar',
+            'poethemeAppSidebar',
+            array(
+                'expandLabel'   => __( 'Espandi menu laterale', 'poetheme' ),
+                'collapseLabel' => __( 'Comprimi menu laterale', 'poetheme' ),
+            )
+        );
+        wp_script_add_data( 'poetheme-app-sidebar', 'defer', true );
     }
 
     if ( poetheme_should_load_media_lightbox() ) {

--- a/inc/nav-menu.php
+++ b/inc/nav-menu.php
@@ -200,7 +200,11 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
                 }
             }
 
+            $icon         = get_post_meta( $item->ID, 'poetheme_menu_icon', true );
             $link_classes = $this->get_link_classes( $depth, $has_children, $item );
+            if ( ! $icon ) {
+                $link_classes .= ' poetheme-nav-link--no-icon';
+            }
             if ( $link_classes ) {
                 $atts['class'] = trim( $link_classes );
             }
@@ -219,7 +223,6 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
 
             $title = apply_filters( 'the_title', $item->title, $item->ID );
 
-            $icon     = get_post_meta( $item->ID, 'poetheme_menu_icon', true );
             $is_bold  = (bool) get_post_meta( $item->ID, 'poetheme_menu_bold', true );
             $icon_svg = '';
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -406,6 +406,18 @@ function poetheme_get_layout_container_classes( $additional = array(), $include_
  * @return string
  */
 function poetheme_get_main_classes() {
+    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
+
+    if ( isset( $header_options['layout'] ) && 'style-9' === $header_options['layout'] ) {
+        $classes = array( 'poetheme-app-content' );
+
+        if ( poetheme_page_has_no_top_padding() ) {
+            $classes[] = 'poetheme-app-content--no-top-padding';
+        }
+
+        return implode( ' ', array_map( 'sanitize_html_class', $classes ) );
+    }
+
     $additional = array( 'pt-10', 'pb-10' );
 
     if ( poetheme_page_has_no_top_padding() ) {
@@ -702,6 +714,94 @@ function poetheme_the_logo() {
     }
 
     echo '</a>';
+}
+
+
+/**
+ * Render the compact site/author profile used by the app sidebar layout.
+ *
+ * @return void
+ */
+function poetheme_render_site_author_profile() {
+    static $profile = null;
+
+    if ( null === $profile ) {
+        $profile = array(
+            'user'        => null,
+            'name'        => get_bloginfo( 'name' ),
+            'description' => get_bloginfo( 'description', 'display' ),
+            'url'         => '',
+        );
+
+        $user_id     = 0;
+        $admin_email = get_option( 'admin_email' );
+
+        if ( $admin_email ) {
+            $admin_user = get_user_by( 'email', $admin_email );
+            if ( $admin_user instanceof WP_User ) {
+                $user_id = (int) $admin_user->ID;
+            }
+        }
+
+        if ( ! $user_id ) {
+            $admin_users = get_users(
+                array(
+                    'role'    => 'administrator',
+                    'number'  => 1,
+                    'orderby' => 'ID',
+                    'order'   => 'ASC',
+                    'fields'  => array( 'ID' ),
+                )
+            );
+
+            if ( ! empty( $admin_users[0]->ID ) ) {
+                $user_id = (int) $admin_users[0]->ID;
+            }
+        }
+
+        $user_id = (int) apply_filters( 'poetheme_sidebar_profile_user_id', $user_id );
+
+        if ( $user_id ) {
+            $user = get_user_by( 'id', $user_id );
+            if ( $user instanceof WP_User ) {
+                $description = get_the_author_meta( 'description', $user_id );
+                $post_count  = count_user_posts( $user_id, 'post', true );
+
+                $profile = array(
+                    'user'        => $user,
+                    'name'        => $user->display_name ? $user->display_name : get_bloginfo( 'name' ),
+                    'description' => $description ? $description : __( 'Autore del sito', 'poetheme' ),
+                    'url'         => $post_count > 0 ? get_author_posts_url( $user_id ) : '',
+                );
+            }
+        }
+    }
+
+    $name        = isset( $profile['name'] ) ? (string) $profile['name'] : get_bloginfo( 'name' );
+    $description = isset( $profile['description'] ) ? (string) $profile['description'] : '';
+    $url         = isset( $profile['url'] ) ? (string) $profile['url'] : '';
+    $user        = isset( $profile['user'] ) ? $profile['user'] : null;
+    $avatar      = $user instanceof WP_User ? get_avatar( $user->ID, 40, '', $name, array( 'class' => 'poetheme-app-sidebar__profile-avatar' ) ) : '';
+
+    if ( ! $avatar ) {
+        $initial = function_exists( 'mb_substr' ) ? mb_substr( $name, 0, 1 ) : substr( $name, 0, 1 );
+        $avatar  = '<span class="poetheme-app-sidebar__profile-avatar poetheme-app-sidebar__profile-avatar--fallback" aria-hidden="true">' . esc_html( strtoupper( $initial ) ) . '</span>';
+    }
+
+    $tag = $url ? 'a' : 'div';
+    ?>
+    <div class="poetheme-app-sidebar__profile">
+        <<?php echo tag_escape( $tag ); ?> class="poetheme-app-sidebar__profile-link"<?php echo $url ? ' href="' . esc_url( $url ) . '"' : ''; ?> aria-label="<?php echo esc_attr( $name ); ?>">
+            <?php echo wp_kses_post( $avatar ); ?>
+            <span class="poetheme-app-sidebar__profile-text">
+                <span class="poetheme-app-sidebar__profile-name"><?php echo esc_html( $name ); ?></span>
+                <?php if ( '' !== trim( $description ) ) : ?>
+                    <span class="poetheme-app-sidebar__profile-description"><?php echo esc_html( wp_trim_words( $description, 6, '…' ) ); ?></span>
+                <?php endif; ?>
+            </span>
+        </<?php echo tag_escape( $tag ); ?>>
+    </div>
+    <?php
 }
 
 /**

--- a/languages/poetheme.pot
+++ b/languages/poetheme.pot
@@ -2454,3 +2454,31 @@ msgstr ""
 #: searchform.php:12
 msgid "Search"
 msgstr ""
+
+#: inc/admin/options.php:119
+msgid "App Sidebar"
+msgstr ""
+
+#: inc/admin/options.php:120
+msgid "Layout con sidebar verticale collassabile, logo in alto, menu laterale, titolo pagina e breadcrumb nell’area contenuto."
+msgstr ""
+
+#: inc/assets.php:292 template-parts/header/style-9.php:36
+msgid "Espandi menu laterale"
+msgstr ""
+
+#: inc/assets.php:293 template-parts/header/style-9.php:36
+msgid "Comprimi menu laterale"
+msgstr ""
+
+#: inc/template-tags.php:704
+msgid "Autore del sito"
+msgstr ""
+
+#: template-parts/header/style-9.php:22
+msgid "Menu laterale del sito"
+msgstr ""
+
+#: template-parts/header/style-9.php:43
+msgid "Navigazione principale"
+msgstr ""

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.8.3
+Version: 1.8.4
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -990,5 +990,357 @@ body.poetheme-lightbox-open {
   .poetheme-lightbox__close {
     top: 0.25rem;
     right: 0.25rem;
+  }
+}
+
+/* Header Style 9: App Sidebar */
+.poetheme-app-shell {
+  --poetheme-app-sidebar-width: 260px;
+  --poetheme-app-sidebar-collapsed-width: 64px;
+  --poetheme-app-sidebar-bg: var(--poetheme-header-background-color, #f7f7f8);
+  --poetheme-app-border: rgba(17, 24, 39, 0.12);
+  min-height: 100vh;
+  background: var(--poetheme-content-background-color, #ffffff);
+}
+
+.poetheme-app-main {
+  min-width: 0;
+  transition: margin-left 180ms ease, width 180ms ease;
+}
+
+.poetheme-app-sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  width: var(--poetheme-app-sidebar-width);
+  height: 100vh;
+  padding: 1rem 0.75rem;
+  overflow-y: auto;
+  background: var(--poetheme-app-sidebar-bg);
+  border-right: 1px solid var(--poetheme-app-border);
+  transition: width 180ms ease;
+}
+
+.poetheme-app-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.poetheme-app-sidebar__brand {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.poetheme-app-sidebar__brand .poetheme-brand-link {
+  color: var(--poetheme-page-title-color, #111827);
+}
+
+.poetheme-app-sidebar__toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--poetheme-app-border);
+  border-radius: 0.625rem;
+  background: #ffffff;
+  color: var(--poetheme-menu-link-color, #374151);
+  cursor: pointer;
+}
+
+.poetheme-app-sidebar__toggle:hover,
+.poetheme-app-sidebar__toggle:focus-visible,
+.poetheme-app-sidebar__profile-link:focus-visible,
+.poetheme-app-sidebar__nav a:focus-visible {
+  outline: 2px solid var(--poetheme-menu-active-link-color, #2563eb);
+  outline-offset: 2px;
+}
+
+.poetheme-app-sidebar__toggle-icon,
+.poetheme-app-sidebar__toggle-icon::before,
+.poetheme-app-sidebar__toggle-icon::after {
+  display: block;
+  width: 1rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.poetheme-app-sidebar__toggle-icon {
+  position: relative;
+}
+
+.poetheme-app-sidebar__toggle-icon::before,
+.poetheme-app-sidebar__toggle-icon::after {
+  position: absolute;
+  left: 0;
+  content: "";
+}
+
+.poetheme-app-sidebar__toggle-icon::before {
+  top: -5px;
+}
+
+.poetheme-app-sidebar__toggle-icon::after {
+  top: 5px;
+}
+
+.poetheme-app-sidebar__nav {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.poetheme-app-sidebar__menu,
+.poetheme-app-sidebar__nav .poetheme-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.poetheme-app-sidebar__nav .poetheme-menu-item {
+  width: 100%;
+}
+
+.poetheme-app-sidebar__nav a {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.75rem;
+  color: var(--poetheme-menu-link-color, #374151);
+  text-decoration: none;
+}
+
+.poetheme-app-sidebar__nav a:hover,
+.poetheme-app-sidebar__nav a:focus,
+.poetheme-app-sidebar__nav .current-menu-item > a,
+.poetheme-app-sidebar__nav .current_page_item > a {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--poetheme-menu-active-link-color, #2563eb);
+}
+
+.poetheme-app-sidebar__nav .menu-item-icon {
+  display: inline-flex;
+  flex: 0 0 1.25rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.poetheme-app-sidebar__nav .poetheme-nav-link--no-icon::before {
+  display: inline-flex;
+  flex: 0 0 1.25rem;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.08);
+  color: currentColor;
+  font-size: 0.7rem;
+  font-weight: 700;
+  content: "•";
+}
+
+.poetheme-app-sidebar__profile {
+  flex: 0 0 auto;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--poetheme-app-border);
+}
+
+.poetheme-app-sidebar__profile-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 0.875rem;
+  color: var(--poetheme-menu-link-color, #374151);
+  text-decoration: none;
+}
+
+.poetheme-app-sidebar__profile-avatar {
+  flex: 0 0 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  object-fit: cover;
+}
+
+.poetheme-app-sidebar__profile-avatar--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #111827;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.poetheme-app-sidebar__profile-text {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.poetheme-app-sidebar__profile-name,
+.poetheme-app-sidebar__profile-description {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.poetheme-app-sidebar__profile-name {
+  color: var(--poetheme-page-title-color, #111827);
+  font-weight: 700;
+}
+
+.poetheme-app-sidebar__profile-description {
+  color: #6b7280;
+  font-size: 0.8125rem;
+}
+
+.poetheme-app-main {
+  margin-left: var(--poetheme-app-sidebar-width);
+}
+
+.poetheme-app-content {
+  width: auto;
+  max-width: none;
+  padding: 2rem clamp(1rem, 3vw, 3rem) 3rem;
+}
+
+.poetheme-app-content--no-top-padding {
+  padding-top: 0;
+}
+
+.poetheme-app-main-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 3vw, 3rem) 1.25rem;
+  border-bottom: 1px solid var(--poetheme-app-border);
+  background: var(--poetheme-content-background-color, #ffffff);
+}
+
+.poetheme-app-page-title {
+  margin: 0;
+  color: var(--poetheme-page-title-color, #111827);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.poetheme-app-breadcrumbs {
+  flex: 0 1 auto;
+  margin-top: 0.35rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+  text-align: right;
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar {
+  width: var(--poetheme-app-sidebar-collapsed-width);
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
+  margin-left: var(--poetheme-app-sidebar-collapsed-width);
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__header {
+  justify-content: center;
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__brand,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .menu-item-text,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .poetheme-submenu-indicator,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav a,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-link {
+  justify-content: center;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .poetheme-app-main,
+  .poetheme-app-sidebar {
+    transition: none;
+  }
+}
+
+@media (max-width: 782px) {
+  .poetheme-app-shell {
+    min-height: auto;
+  }
+
+  .poetheme-app-sidebar {
+    position: relative;
+    width: 100%;
+    height: auto;
+    max-height: none;
+    border-right: 0;
+    border-bottom: 1px solid var(--poetheme-app-border);
+  }
+
+  .poetheme-app-main,
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
+    margin-left: 0;
+  }
+
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar {
+    width: 100%;
+  }
+
+  .poetheme-app-main-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .poetheme-app-breadcrumbs {
+    text-align: left;
+  }
+}
+
+@media (max-width: 782px) {
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__brand,
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .menu-item-text,
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .poetheme-submenu-indicator,
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-text {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: initial;
+    margin: initial;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    border: 0;
+  }
+
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav a,
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-link {
+    justify-content: flex-start;
   }
 }

--- a/template-parts/header/style-9.php
+++ b/template-parts/header/style-9.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Header layout: Style 9 (App Sidebar).
+ *
+ * @package PoeTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$sidebar_id        = 'poetheme-app-sidebar';
+$title_text        = poetheme_get_subheader_title_text();
+$breadcrumbs_items = poetheme_get_breadcrumbs_items();
+?>
+<div class="poetheme-app-shell poetheme-app-shell--sidebar-expanded" data-poetheme-app-shell>
+    <aside id="<?php echo esc_attr( $sidebar_id ); ?>" class="poetheme-app-sidebar" aria-label="<?php esc_attr_e( 'Menu laterale del sito', 'poetheme' ); ?>">
+        <div class="poetheme-app-sidebar__header">
+            <div class="poetheme-app-sidebar__brand">
+                <?php poetheme_the_logo(); ?>
+            </div>
+            <button
+                type="button"
+                class="poetheme-app-sidebar__toggle"
+                data-poetheme-app-sidebar-toggle
+                aria-expanded="true"
+                aria-controls="<?php echo esc_attr( $sidebar_id ); ?>"
+            >
+                <span class="poetheme-app-sidebar__toggle-icon" aria-hidden="true"></span>
+                <span class="screen-reader-text" data-poetheme-app-sidebar-toggle-label>
+                    <?php esc_html_e( 'Comprimi menu laterale', 'poetheme' ); ?>
+                </span>
+            </button>
+        </div>
+
+        <nav class="poetheme-app-sidebar__nav" aria-label="<?php esc_attr_e( 'Navigazione principale', 'poetheme' ); ?>">
+            <?php
+            poetheme_render_navigation_menu(
+                'primary',
+                'desktop',
+                array(
+                    'menu_class' => 'poetheme-app-sidebar__menu',
+                )
+            );
+            ?>
+        </nav>
+
+        <?php poetheme_render_site_author_profile(); ?>
+    </aside>
+
+    <div class="poetheme-app-main">
+        <header class="poetheme-app-main-header">
+            <div class="poetheme-app-main-header__title-wrap">
+                <?php if ( '' !== trim( $title_text ) ) : ?>
+                    <h1 class="poetheme-app-page-title" itemprop="headline"><?php echo esc_html( $title_text ); ?></h1>
+                <?php endif; ?>
+            </div>
+
+            <?php if ( ! empty( $breadcrumbs_items ) ) : ?>
+                <nav class="poetheme-app-breadcrumbs" aria-label="<?php esc_attr_e( 'Breadcrumb', 'poetheme' ); ?>">
+                    <?php echo poetheme_get_breadcrumbs_markup( $breadcrumbs_items, poetheme_get_breadcrumbs_separator() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </nav>
+            <?php endif; ?>
+        </header>


### PR DESCRIPTION
### Motivation
- Provide a new dashboard-like header layout (Style 9 “App Sidebar”) with a vertical, collapsible sidebar, keeping header/subheader helpers and site features reusable and accessible.
- Reuse existing menu/logo/breadcrumb/title helpers and centralize header layout choices to avoid duplication and make the new layout selectable and validated in the admin UI.

### Description
- Added a centralized header layout registry `poetheme_get_header_layout_choices()` and switched admin UI and sanitization to use it, registering `style-9` labeled `App Sidebar` with a description and admin preview support (`inc/admin/options.php`).
- Implemented the new template `template-parts/header/style-9.php` which renders the app shell, left sidebar with logo, accessible toggle, primary navigation, compact site/author profile, and the main topbar containing page title and breadcrumbs.
- Prevented duplicate page title/breadcrumb output by conditionally skipping `poetheme_render_subheader()` for `style-9` in `header.php`, added matching shell closure in `footer.php`, and adjusted `poetheme_get_main_classes()` to return fluid app-specific classes for `style-9` (`inc/template-tags.php`).
- Added `poetheme_render_site_author_profile()` helper to render a safe compact profile in the sidebar, created a lightweight vanilla JS toggle `assets/js/app-sidebar.js` with `aria-expanded`, `aria-controls`, screen-reader labels and `localStorage` persistence, enqueued conditionally in `inc/assets.php`, and added supporting CSS in `style.css` plus admin preview styles in `assets/css/admin-header-layouts.css`.
- Minor nav walker tweak to add `poetheme-nav-link--no-icon` support for menu items without icons, updated POT strings for new labels, and bumped theme version to `1.8.4` in `style.css` and `functions.php`.

### Testing
- Ran PHP syntax checks across the codebase with `php -l` for each PHP file, which completed with no syntax errors.
- Validated the new JavaScript with `node --check assets/js/app-sidebar.js`, which passed without errors.
- Ran `git diff --check` to detect whitespace/patch issues and found no problems in the diffs checked.
- Attempted to regenerate translation POT via `wp i18n make-pot . languages/poetheme.pot`, but `wp` (WP-CLI) is not available in the environment so POT entries were added manually and included in `languages/poetheme.pot`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297d7afaec8332a73b27dd8f5b8240)