### PR TITLE
Fix App Sidebar (style-9): subheader logic, sidebar variant, mobile drawer, author profile and CSS/JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Obiettivo: garantire la conformità a livello di tema (struttura, navigazione, f
 - Testi dei link/CTA descrittivi.
 - Alt text per immagini editoriali.
 
+
+## Note versione 1.8.5
+- Corretto il layout **Style 9 – App Sidebar** affinché il titolo pagina rispetti `enable_subheader`, `show_title`, `hide_title` e il tag `title_tag` configurato.
+- Aggiunta variante menu `sidebar` con accordion verticale multilivello per evitare il clipping del terzo livello sotto il contenuto principale.
+- Aggiunto drawer mobile da destra con overlay, chiusura via ESC/click overlay e stato ARIA aggiornato.
+- Spostato il profilo autore in fondo al drawer mobile mantenendo la versione desktop nella sidebar.
+- Aggiornata l’icona del toggle sidebar con SVG inline a pannello laterale, senza sfondo o bordo.
+
+## Checklist audit Style 9 – App Sidebar
+- **Applicate:** layout header selezionato, logo via `poetheme_the_logo()`, menu primary, `enable_subheader`, `show_title`, `show_breadcrumbs`, `title_tag`, `breadcrumbs_separator`, `hide_title`, `hide_breadcrumbs`, remove top padding, colori dinamici per titolo/menu/sidebar, layout contenuto fluido, responsive menu e supporto RTL di base.
+- **Non applicabili al layout:** top bar e CTA degli header classici non vengono mostrati nello Style 9 perché il pattern App Sidebar usa navigazione laterale/drawer e non una barra header orizzontale.
+- **Da verificare in una fase successiva:** equivalenza visiva completa di font/dimensioni titolo rispetto a ogni combinazione legacy e audit manuale footer visibility su installazioni con plugin/child theme.
+- **Test manuali consigliati:** cambio layout header; logo testuale/immagine; title tag H1–H6; show/hide title; show/hide breadcrumb; separatore breadcrumb; impostazioni pagina hide title/hide breadcrumb/remove top padding; colori heading/menu; font heading/page title; footer visibility; menu responsive desktop/mobile; menu sidebar con almeno tre livelli.
+
 ## Mappa architetturale
 - `functions.php`: bootstrap con costanti e include.
 - `inc/setup.php`: setup tema (supporti, menu, textdomain).

--- a/assets/js/app-sidebar.js
+++ b/assets/js/app-sidebar.js
@@ -2,6 +2,17 @@
     'use strict';
 
     var storageKey = 'poethemeAppSidebarCollapsed';
+    var desktopQuery = '(min-width: 768px)';
+    var lastDrawerTrigger = null;
+
+    function getLabels() {
+        return window.poethemeAppSidebar || {
+            expandLabel: 'Espandi menu laterale',
+            collapseLabel: 'Comprimi menu laterale',
+            openMenuLabel: 'Apri menu mobile',
+            closeMenuLabel: 'Chiudi menu mobile'
+        };
+    }
 
     function getStoredState() {
         try {
@@ -18,6 +29,7 @@
     }
 
     function updateShell(shell, toggle, isCollapsed) {
+        var labels = getLabels();
         var label = toggle ? toggle.querySelector('[data-poetheme-app-sidebar-toggle-label]') : null;
 
         shell.classList.toggle('is-sidebar-collapsed', isCollapsed);
@@ -25,14 +37,157 @@
 
         if (toggle) {
             toggle.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
-            toggle.setAttribute(
-                'aria-label',
-                isCollapsed ? poethemeAppSidebar.expandLabel : poethemeAppSidebar.collapseLabel
-            );
+            toggle.setAttribute('aria-label', isCollapsed ? labels.expandLabel : labels.collapseLabel);
         }
 
         if (label) {
-            label.textContent = isCollapsed ? poethemeAppSidebar.expandLabel : poethemeAppSidebar.collapseLabel;
+            label.textContent = isCollapsed ? labels.expandLabel : labels.collapseLabel;
+        }
+    }
+
+    function initSidebarAccordion(scope) {
+        var menus = scope.querySelectorAll('[data-poetheme-nav="1"][data-variant="sidebar"]');
+
+        menus.forEach(function (menu) {
+            var items = menu.querySelectorAll('li.menu-item-has-children');
+
+            items.forEach(function (item) {
+                var trigger = item.querySelector(':scope > .poetheme-mobile-item-row > .poetheme-submenu-toggle');
+                var submenu = item.querySelector(':scope > [data-poetheme-submenu="true"]');
+
+                if (!trigger || !submenu) {
+                    return;
+                }
+
+                function setOpen(isOpen) {
+                    item.classList.toggle('is-open', isOpen);
+                    trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                    submenu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+                }
+
+                setOpen(item.classList.contains('current-menu-ancestor') || item.classList.contains('current-menu-item'));
+
+                trigger.addEventListener('click', function () {
+                    setOpen(!item.classList.contains('is-open'));
+                });
+
+                item.addEventListener('keydown', function (event) {
+                    if (event.key === 'Escape' && item.classList.contains('is-open')) {
+                        event.preventDefault();
+                        setOpen(false);
+                        trigger.focus();
+                    }
+                });
+            });
+
+            menu.setAttribute('data-ready', 'true');
+        });
+    }
+
+    function getFocusable(container) {
+        return Array.prototype.slice.call(
+            container.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')
+        ).filter(function (element) {
+            return element.offsetParent !== null || element === document.activeElement;
+        });
+    }
+
+    function initMobileDrawer(shell) {
+        var labels = getLabels();
+        var toggle = document.querySelector('[data-poetheme-app-mobile-toggle]');
+        var drawer = document.querySelector('[data-poetheme-app-mobile-drawer]');
+        var overlay = document.querySelector('[data-poetheme-app-mobile-overlay]');
+        var closeButton = document.querySelector('[data-poetheme-app-mobile-close]');
+        var mediaQuery = window.matchMedia(desktopQuery);
+
+        if (!toggle || !drawer || !overlay) {
+            return;
+        }
+
+        function setDrawerOpen(isOpen) {
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            toggle.setAttribute('aria-label', isOpen ? labels.closeMenuLabel : labels.openMenuLabel);
+            drawer.classList.toggle('is-open', isOpen);
+            overlay.classList.toggle('is-open', isOpen);
+            drawer.hidden = !isOpen;
+            overlay.hidden = !isOpen;
+            drawer.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+            document.body.classList.toggle('poetheme-mobile-drawer-open', isOpen);
+
+            if (shell) {
+                shell.classList.toggle('is-mobile-drawer-open', isOpen);
+            }
+
+            if (isOpen) {
+                lastDrawerTrigger = document.activeElement;
+                window.setTimeout(function () {
+                    var focusables = getFocusable(drawer);
+                    (focusables[0] || drawer).focus();
+                }, 0);
+            } else if (lastDrawerTrigger && typeof lastDrawerTrigger.focus === 'function') {
+                lastDrawerTrigger.focus();
+                lastDrawerTrigger = null;
+            }
+        }
+
+        function closeDrawer() {
+            setDrawerOpen(false);
+        }
+
+        toggle.addEventListener('click', function () {
+            setDrawerOpen(toggle.getAttribute('aria-expanded') !== 'true');
+        });
+
+        if (closeButton) {
+            closeButton.addEventListener('click', closeDrawer);
+        }
+
+        overlay.addEventListener('click', closeDrawer);
+
+        drawer.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeDrawer();
+                return;
+            }
+
+            if (event.key !== 'Tab') {
+                return;
+            }
+
+            var focusables = getFocusable(drawer);
+            var first = focusables[0];
+            var last = focusables[focusables.length - 1];
+
+            if (!first || !last) {
+                return;
+            }
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        });
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape' && drawer.classList.contains('is-open')) {
+                closeDrawer();
+            }
+        });
+
+        function handleViewportChange(event) {
+            if (event.matches && drawer.classList.contains('is-open')) {
+                closeDrawer();
+            }
+        }
+
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', handleViewportChange);
+        } else if (typeof mediaQuery.addListener === 'function') {
+            mediaQuery.addListener(handleViewportChange);
         }
     }
 
@@ -40,16 +195,21 @@
         var shell = document.querySelector('[data-poetheme-app-shell]');
         var toggle = document.querySelector('[data-poetheme-app-sidebar-toggle]');
 
-        if (!shell || !toggle || typeof poethemeAppSidebar === 'undefined') {
+        if (!shell) {
             return;
         }
 
-        updateShell(shell, toggle, getStoredState());
+        if (toggle) {
+            updateShell(shell, toggle, getStoredState());
 
-        toggle.addEventListener('click', function () {
-            var isCollapsed = !shell.classList.contains('is-sidebar-collapsed');
-            updateShell(shell, toggle, isCollapsed);
-            setStoredState(isCollapsed);
-        });
+            toggle.addEventListener('click', function () {
+                var isCollapsed = !shell.classList.contains('is-sidebar-collapsed');
+                updateShell(shell, toggle, isCollapsed);
+                setStoredState(isCollapsed);
+            });
+        }
+
+        initSidebarAccordion(shell);
+        initMobileDrawer(shell);
     });
 }());

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.8.4' );
+define( 'POETHEME_VERSION', '1.8.5' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -293,6 +293,8 @@ function poetheme_scripts() {
             array(
                 'expandLabel'   => __( 'Espandi menu laterale', 'poetheme' ),
                 'collapseLabel' => __( 'Comprimi menu laterale', 'poetheme' ),
+                'openMenuLabel' => __( 'Apri menu mobile', 'poetheme' ),
+                'closeMenuLabel' => __( 'Chiudi menu mobile', 'poetheme' ),
             )
         );
         wp_script_add_data( 'poetheme-app-sidebar', 'defer', true );

--- a/inc/nav-menu.php
+++ b/inc/nav-menu.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
         protected $layout = 'primary';
 
         /**
-         * Menu variant (desktop or mobile).
+         * Menu variant (desktop, mobile, or sidebar).
          *
          * @var string
          */
@@ -79,8 +79,11 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $parent_id = ! empty( $this->submenu_stack ) ? end( $this->submenu_stack ) : 0;
             $submenu_id = $parent_id && isset( $this->submenu_ids[ $parent_id ] ) ? $this->submenu_ids[ $parent_id ] : '';
 
-            if ( 'mobile' === $this->variant ) {
+            if ( in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
                 $classes = array( 'poetheme-submenu', 'pl-4', 'border-l', 'border-gray-200', 'space-y-2', 'mt-2' );
+                if ( 'sidebar' === $this->variant ) {
+                    $classes = array( 'poetheme-submenu', 'poetheme-sidebar-submenu' );
+                }
                 if ( $depth > 0 ) {
                     $classes[] = 'ml-2';
                 }
@@ -166,7 +169,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
 
             $li_classes = array( 'poetheme-menu-item', 'relative' );
 
-            if ( 'mobile' !== $this->variant && $has_children ) {
+            if ( 'desktop' === $this->variant && $has_children ) {
                 $li_classes[] = 'group';
             }
 
@@ -190,7 +193,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
             $atts['href']   = ! empty( $item->url ) ? $item->url : '';
 
-            if ( $has_children && 'mobile' !== $this->variant ) {
+            if ( $has_children && 'desktop' === $this->variant ) {
                 $atts['aria-haspopup'] = 'true';
                 $atts['aria-expanded'] = 'false';
                 if ( $submenu_id ) {
@@ -231,14 +234,14 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             }
 
             $indicator = '';
-            if ( $has_children && 'mobile' !== $this->variant ) {
+            if ( $has_children && 'desktop' === $this->variant ) {
                 $indicator_icon    = ( 0 === $depth ) ? 'chevron-down' : 'chevron-right';
                 $indicator_classes = array( 'poetheme-submenu-indicator', 'w-4', 'h-4', 'ml-1', 'text-gray-400' );
                 $indicator         = '<i data-lucide="' . esc_attr( $indicator_icon ) . '" class="' . esc_attr( implode( ' ', $indicator_classes ) ) . '"></i>';
             }
 
             $submenu_toggle = '';
-            if ( $has_children && 'mobile' === $this->variant ) {
+            if ( $has_children && in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
                 $toggle_label = sprintf(
                     /* translators: %s: menu item title */
                     __( 'Apri il sottomenu di %s', 'poetheme' ),
@@ -254,7 +257,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $title_markup = '<span class="menu-item-text' . ( $is_bold ? ' font-semibold' : '' ) . '">' . esc_html( $title ) . '</span>';
 
             $item_output  = $args->before;
-            if ( $has_children && 'mobile' === $this->variant ) {
+            if ( $has_children && in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
                 $item_output .= '<div class="poetheme-mobile-item-row">';
             }
             $item_output .= '<a' . $attributes . '>';
@@ -277,7 +280,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
                 $item_output .= $submenu_toggle;
             }
 
-            if ( $has_children && 'mobile' === $this->variant ) {
+            if ( $has_children && in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
                 $item_output .= '</div>';
             }
             $item_output .= $args->after;
@@ -318,7 +321,7 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $classes = array( 'inline-flex', 'items-center', 'gap-2', 'transition', 'duration-150', 'ease-out' );
             $is_primary_layout = ( 'primary' === $this->layout );
 
-            if ( 'mobile' === $this->variant ) {
+            if ( in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
                 $classes = array( 'flex', 'items-center', 'gap-2', 'flex-1', 'text-left', 'transition', 'duration-150' );
                 $classes[] = ( 0 === $depth ) ? 'text-base' : 'text-sm';
                 $classes[] = 'text-gray-800';
@@ -373,7 +376,7 @@ if ( ! function_exists( 'poetheme_render_navigation_menu' ) ) {
      * Helper function to render theme menus with the custom walker.
      *
      * @param string $location Menu location slug.
-     * @param string $variant  Menu variant (desktop or mobile).
+     * @param string $variant  Menu variant (desktop, mobile, or sidebar).
      * @param array  $args     Additional arguments passed to wp_nav_menu().
      */
     function poetheme_render_navigation_menu( $location, $variant = 'desktop', $args = array() ) {
@@ -392,17 +395,18 @@ if ( ! function_exists( 'poetheme_render_navigation_menu' ) ) {
 
         $walker_args         = array(
             'layout'  => ( 'top-info' === $location ) ? 'top-info' : 'primary',
-            'variant' => ( 'mobile' === $variant ) ? 'mobile' : 'desktop',
+            'variant' => in_array( $variant, array( 'mobile', 'sidebar' ), true ) ? $variant : 'desktop',
         );
         $defaults['walker']   = new PoeTheme_Nav_Walker( $walker_args );
 
-        if ( 'mobile' === $variant ) {
+        if ( in_array( $variant, array( 'mobile', 'sidebar' ), true ) ) {
             $defaults['depth'] = 0;
         }
 
         $args = wp_parse_args( $args, $defaults );
 
-        $base_classes = array( 'poetheme-nav', 'poetheme-nav--' . ( 'mobile' === $variant ? 'mobile' : 'desktop' ) );
+        $menu_variant = in_array( $variant, array( 'mobile', 'sidebar' ), true ) ? $variant : 'desktop';
+        $base_classes = array( 'poetheme-nav', 'poetheme-nav--' . $menu_variant );
         if ( $location ) {
             $base_classes[] = 'poetheme-nav--location-' . sanitize_html_class( $location );
         }
@@ -422,7 +426,7 @@ if ( ! function_exists( 'poetheme_get_navigation_menu_items' ) ) {
      * Return navigation menu items markup only (without wrapping <ul>).
      *
      * @param string $location Menu location slug.
-     * @param string $variant  Menu variant (desktop or mobile).
+     * @param string $variant  Menu variant (desktop, mobile, or sidebar).
      * @param array  $args     Additional arguments passed to wp_nav_menu().
      * @return string
      */
@@ -443,11 +447,11 @@ if ( ! function_exists( 'poetheme_get_navigation_menu_items' ) ) {
 
         $walker_args          = array(
             'layout'  => ( 'top-info' === $location ) ? 'top-info' : 'primary',
-            'variant' => ( 'mobile' === $variant ) ? 'mobile' : 'desktop',
+            'variant' => in_array( $variant, array( 'mobile', 'sidebar' ), true ) ? $variant : 'desktop',
         );
         $defaults['walker']   = new PoeTheme_Nav_Walker( $walker_args );
 
-        if ( 'mobile' === $variant ) {
+        if ( in_array( $variant, array( 'mobile', 'sidebar' ), true ) ) {
             $defaults['depth'] = 0;
         }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -720,9 +720,17 @@ function poetheme_the_logo() {
 /**
  * Render the compact site/author profile used by the app sidebar layout.
  *
+ * @param array $args Profile rendering arguments.
  * @return void
  */
-function poetheme_render_site_author_profile() {
+function poetheme_render_site_author_profile( $args = array() ) {
+    $args    = wp_parse_args(
+        $args,
+        array(
+            'context' => 'desktop',
+        )
+    );
+    $context = in_array( $args['context'], array( 'desktop', 'mobile' ), true ) ? $args['context'] : 'desktop';
     static $profile = null;
 
     if ( null === $profile ) {
@@ -790,7 +798,7 @@ function poetheme_render_site_author_profile() {
 
     $tag = $url ? 'a' : 'div';
     ?>
-    <div class="poetheme-app-sidebar__profile">
+    <div class="poetheme-app-sidebar__profile poetheme-app-sidebar__profile--<?php echo esc_attr( $context ); ?>">
         <<?php echo tag_escape( $tag ); ?> class="poetheme-app-sidebar__profile-link"<?php echo $url ? ' href="' . esc_url( $url ) . '"' : ''; ?> aria-label="<?php echo esc_attr( $name ); ?>">
             <?php echo wp_kses_post( $avatar ); ?>
             <span class="poetheme-app-sidebar__profile-text">

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.8.4
+Version: 1.8.5
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -1005,100 +1005,121 @@ body.poetheme-lightbox-open {
 
 .poetheme-app-main {
   min-width: 0;
+  margin-left: var(--poetheme-app-sidebar-width);
   transition: margin-left 180ms ease, width 180ms ease;
 }
 
 .poetheme-app-sidebar {
   position: fixed;
   inset: 0 auto 0 0;
-  z-index: 40;
+  z-index: 60;
   display: flex;
   flex-direction: column;
   width: var(--poetheme-app-sidebar-width);
   height: 100vh;
   padding: 1rem 0.75rem;
-  overflow-y: auto;
+  overflow: visible;
   background: var(--poetheme-app-sidebar-bg);
   border-right: 1px solid var(--poetheme-app-border);
   transition: width 180ms ease;
 }
 
-.poetheme-app-sidebar__header {
+.rtl .poetheme-app-sidebar {
+  inset: 0 0 0 auto;
+  border-right: 0;
+  border-left: 1px solid var(--poetheme-app-border);
+}
+
+.rtl .poetheme-app-main {
+  margin-right: var(--poetheme-app-sidebar-width);
+  margin-left: 0;
+}
+
+.poetheme-app-sidebar__header,
+.poetheme-app-mobile-bar,
+.poetheme-app-mobile-drawer__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
+}
+
+.poetheme-app-sidebar__header {
+  flex: 0 0 auto;
   min-height: 2.75rem;
   margin-bottom: 1.5rem;
 }
 
-.poetheme-app-sidebar__brand {
+.poetheme-app-sidebar__brand,
+.poetheme-app-mobile-bar__brand,
+.poetheme-app-mobile-drawer__brand {
   min-width: 0;
   overflow: hidden;
 }
 
-.poetheme-app-sidebar__brand .poetheme-brand-link {
+.poetheme-app-sidebar__brand .poetheme-brand-link,
+.poetheme-app-mobile-bar__brand .poetheme-brand-link,
+.poetheme-app-mobile-drawer__brand .poetheme-brand-link {
   color: var(--poetheme-page-title-color, #111827);
 }
 
-.poetheme-app-sidebar__toggle {
+.poetheme-app-sidebar__toggle,
+.poetheme-app-mobile-toggle,
+.poetheme-app-mobile-drawer__close {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   width: 2.25rem;
   height: 2.25rem;
-  border: 1px solid var(--poetheme-app-border);
-  border-radius: 0.625rem;
-  background: #ffffff;
+  padding: 0.25rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: transparent;
+  box-shadow: none;
   color: var(--poetheme-menu-link-color, #374151);
   cursor: pointer;
 }
 
 .poetheme-app-sidebar__toggle:hover,
+.poetheme-app-mobile-toggle:hover,
+.poetheme-app-mobile-drawer__close:hover {
+  color: var(--poetheme-menu-active-link-color, #2563eb);
+}
+
 .poetheme-app-sidebar__toggle:focus-visible,
+.poetheme-app-mobile-toggle:focus-visible,
+.poetheme-app-mobile-drawer__close:focus-visible,
 .poetheme-app-sidebar__profile-link:focus-visible,
-.poetheme-app-sidebar__nav a:focus-visible {
+.poetheme-app-sidebar__nav a:focus-visible,
+.poetheme-app-sidebar__nav .poetheme-submenu-toggle:focus-visible,
+.poetheme-app-mobile-drawer a:focus-visible,
+.poetheme-app-mobile-drawer .poetheme-submenu-toggle:focus-visible {
   outline: 2px solid var(--poetheme-menu-active-link-color, #2563eb);
   outline-offset: 2px;
 }
 
-.poetheme-app-sidebar__toggle-icon,
-.poetheme-app-sidebar__toggle-icon::before,
-.poetheme-app-sidebar__toggle-icon::after {
-  display: block;
-  width: 1rem;
-  height: 2px;
-  border-radius: 999px;
-  background: currentColor;
-}
-
 .poetheme-app-sidebar__toggle-icon {
-  position: relative;
-}
-
-.poetheme-app-sidebar__toggle-icon::before,
-.poetheme-app-sidebar__toggle-icon::after {
-  position: absolute;
-  left: 0;
-  content: "";
-}
-
-.poetheme-app-sidebar__toggle-icon::before {
-  top: -5px;
-}
-
-.poetheme-app-sidebar__toggle-icon::after {
-  top: 5px;
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .poetheme-app-sidebar__nav {
   flex: 1 1 auto;
   min-height: 0;
+  overflow-x: visible;
+  overflow-y: auto;
 }
 
 .poetheme-app-sidebar__menu,
-.poetheme-app-sidebar__nav .poetheme-nav {
+.poetheme-app-sidebar__nav .poetheme-nav,
+.poetheme-app-mobile-drawer__menu,
+.poetheme-app-mobile-drawer__nav .poetheme-nav {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -1107,11 +1128,20 @@ body.poetheme-lightbox-open {
   list-style: none;
 }
 
-.poetheme-app-sidebar__nav .poetheme-menu-item {
+.poetheme-app-sidebar__nav .poetheme-menu-item,
+.poetheme-app-mobile-drawer__nav .poetheme-menu-item {
   width: 100%;
 }
 
-.poetheme-app-sidebar__nav a {
+.poetheme-app-sidebar__nav .poetheme-mobile-item-row,
+.poetheme-app-mobile-drawer__nav .poetheme-mobile-item-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.poetheme-app-sidebar__nav a,
+.poetheme-app-mobile-drawer__nav a {
   width: 100%;
   min-height: 2.5rem;
   padding: 0.625rem 0.75rem;
@@ -1123,19 +1153,56 @@ body.poetheme-lightbox-open {
 .poetheme-app-sidebar__nav a:hover,
 .poetheme-app-sidebar__nav a:focus,
 .poetheme-app-sidebar__nav .current-menu-item > a,
-.poetheme-app-sidebar__nav .current_page_item > a {
+.poetheme-app-sidebar__nav .current_page_item > a,
+.poetheme-app-mobile-drawer__nav a:hover,
+.poetheme-app-mobile-drawer__nav a:focus,
+.poetheme-app-mobile-drawer__nav .current-menu-item > a,
+.poetheme-app-mobile-drawer__nav .current_page_item > a {
   background: rgba(37, 99, 235, 0.08);
   color: var(--poetheme-menu-active-link-color, #2563eb);
 }
 
-.poetheme-app-sidebar__nav .menu-item-icon {
+.poetheme-app-sidebar__nav .poetheme-submenu-toggle,
+.poetheme-app-mobile-drawer__nav .poetheme-submenu-toggle {
+  flex: 0 0 2.25rem;
+  min-height: 2.25rem;
+  border: 0;
+  border-radius: 0.625rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+.poetheme-app-sidebar__nav .poetheme-submenu,
+.poetheme-app-mobile-drawer__nav .poetheme-submenu {
+  display: none;
+  position: static;
+  width: auto;
+  margin: 0.25rem 0 0 0.75rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--poetheme-app-border);
+  box-shadow: none;
+}
+
+.poetheme-app-sidebar__nav .is-open > .poetheme-submenu,
+.poetheme-app-mobile-drawer__nav .is-open > .poetheme-submenu {
+  display: flex;
+}
+
+.poetheme-app-sidebar__nav .is-open > .poetheme-mobile-item-row .poetheme-submenu-indicator,
+.poetheme-app-mobile-drawer__nav .is-open > .poetheme-mobile-item-row .poetheme-submenu-indicator {
+  transform: rotate(180deg);
+}
+
+.poetheme-app-sidebar__nav .menu-item-icon,
+.poetheme-app-mobile-drawer__nav .menu-item-icon {
   display: inline-flex;
   flex: 0 0 1.25rem;
   align-items: center;
   justify-content: center;
 }
 
-.poetheme-app-sidebar__nav .poetheme-nav-link--no-icon::before {
+.poetheme-app-sidebar__nav .poetheme-nav-link--no-icon::before,
+.poetheme-app-mobile-drawer__nav .poetheme-nav-link--no-icon::before {
   display: inline-flex;
   flex: 0 0 1.25rem;
   align-items: center;
@@ -1155,6 +1222,10 @@ body.poetheme-lightbox-open {
   margin-top: 1.5rem;
   padding-top: 1rem;
   border-top: 1px solid var(--poetheme-app-border);
+}
+
+.poetheme-app-sidebar__profile--mobile {
+  display: none;
 }
 
 .poetheme-app-sidebar__profile-link {
@@ -1207,10 +1278,6 @@ body.poetheme-lightbox-open {
   font-size: 0.8125rem;
 }
 
-.poetheme-app-main {
-  margin-left: var(--poetheme-app-sidebar-width);
-}
-
 .poetheme-app-content {
   width: auto;
   max-width: none;
@@ -1219,6 +1286,13 @@ body.poetheme-lightbox-open {
 
 .poetheme-app-content--no-top-padding {
   padding-top: 0;
+}
+
+.poetheme-app-mobile-bar {
+  display: none;
+  padding: 0.875rem clamp(1rem, 3vw, 3rem);
+  border-bottom: 1px solid var(--poetheme-app-border);
+  background: var(--poetheme-app-sidebar-bg);
 }
 
 .poetheme-app-main-header {
@@ -1242,7 +1316,7 @@ body.poetheme-lightbox-open {
 .poetheme-app-breadcrumbs {
   flex: 0 1 auto;
   margin-top: 0.35rem;
-  color: #6b7280;
+  color: var(--poetheme-breadcrumb-color, #6b7280);
   font-size: 0.875rem;
   text-align: right;
 }
@@ -1255,6 +1329,11 @@ body.poetheme-lightbox-open {
 
 .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
   margin-left: var(--poetheme-app-sidebar-collapsed-width);
+}
+
+.rtl .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
+  margin-right: var(--poetheme-app-sidebar-collapsed-width);
+  margin-left: 0;
 }
 
 .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__header {
@@ -1283,34 +1362,97 @@ body.poetheme-lightbox-open {
   padding-left: 0.5rem;
 }
 
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .poetheme-submenu-toggle,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .poetheme-submenu {
+  display: none;
+}
+
+.poetheme-app-mobile-overlay[hidden],
+.poetheme-app-mobile-drawer[hidden] {
+  display: none !important;
+}
+
+.poetheme-app-mobile-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(17, 24, 39, 0.55);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.poetheme-app-mobile-overlay.is-open {
+  opacity: 1;
+}
+
+.poetheme-app-mobile-drawer {
+  position: fixed;
+  inset: 0 0 0 auto;
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  width: min(88vw, 22rem);
+  height: 100vh;
+  padding: 1rem;
+  overflow-y: auto;
+  background: var(--poetheme-app-sidebar-bg);
+  border-left: 1px solid var(--poetheme-app-border);
+  transform: translateX(100%);
+  transition: transform 220ms ease;
+}
+
+.rtl .poetheme-app-mobile-drawer {
+  inset: 0 auto 0 0;
+  border-right: 1px solid var(--poetheme-app-border);
+  border-left: 0;
+  transform: translateX(-100%);
+}
+
+.poetheme-app-mobile-drawer.is-open {
+  transform: translateX(0);
+}
+
+.poetheme-app-mobile-drawer__header {
+  flex: 0 0 auto;
+  margin-bottom: 1rem;
+}
+
+.poetheme-app-mobile-drawer__nav {
+  flex: 1 1 auto;
+}
+
+body.poetheme-mobile-drawer-open {
+  overflow: hidden;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .poetheme-app-main,
-  .poetheme-app-sidebar {
+  .poetheme-app-sidebar,
+  .poetheme-app-mobile-overlay,
+  .poetheme-app-mobile-drawer {
     transition: none;
   }
 }
 
-@media (max-width: 782px) {
+@media (max-width: 767.98px) {
   .poetheme-app-shell {
     min-height: auto;
   }
 
   .poetheme-app-sidebar {
-    position: relative;
-    width: 100%;
-    height: auto;
-    max-height: none;
-    border-right: 0;
-    border-bottom: 1px solid var(--poetheme-app-border);
+    display: none;
   }
 
   .poetheme-app-main,
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
+  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main,
+  .rtl .poetheme-app-main,
+  .rtl .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-main {
+    margin-right: 0;
     margin-left: 0;
   }
 
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar {
-    width: 100%;
+  .poetheme-app-mobile-bar {
+    display: flex;
   }
 
   .poetheme-app-main-header {
@@ -1321,26 +1463,8 @@ body.poetheme-lightbox-open {
   .poetheme-app-breadcrumbs {
     text-align: left;
   }
-}
 
-@media (max-width: 782px) {
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__brand,
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .menu-item-text,
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .poetheme-submenu-indicator,
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-text {
-    position: static;
-    width: auto;
-    height: auto;
-    padding: initial;
-    margin: initial;
-    overflow: visible;
-    clip: auto;
-    white-space: normal;
-    border: 0;
-  }
-
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav a,
-  .poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__profile-link {
-    justify-content: flex-start;
+  .poetheme-app-sidebar__profile--mobile {
+    display: block;
   }
 }

--- a/template-parts/header/style-9.php
+++ b/template-parts/header/style-9.php
@@ -9,9 +9,28 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$sidebar_id        = 'poetheme-app-sidebar';
-$title_text        = poetheme_get_subheader_title_text();
-$breadcrumbs_items = poetheme_get_breadcrumbs_items();
+$sidebar_id           = 'poetheme-app-sidebar';
+$mobile_drawer_id     = 'poetheme-app-mobile-drawer';
+$subheader_options    = poetheme_get_subheader_options();
+$show_title           = poetheme_subheader_should_display_title();
+$show_breadcrumbs     = poetheme_subheader_should_display_breadcrumbs();
+$breadcrumbs_items    = $show_breadcrumbs ? poetheme_get_breadcrumbs_items() : array();
+$title_text           = '';
+$title_tag            = isset( $subheader_options['title_tag'] ) ? strtolower( (string) $subheader_options['title_tag'] ) : 'h1';
+$allowed_title_tags   = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
+$title_classes        = array_merge( array( 'poetheme-app-page-title' ), poetheme_get_subheader_title_classes() );
+$title_classes        = implode( ' ', array_map( 'sanitize_html_class', array_unique( $title_classes ) ) );
+
+if ( ! in_array( $title_tag, $allowed_title_tags, true ) ) {
+    $title_tag = 'h1';
+}
+
+if ( $show_title ) {
+    $title_text = poetheme_get_subheader_title_text();
+    if ( '' === trim( $title_text ) ) {
+        $show_title = false;
+    }
+}
 ?>
 <div class="poetheme-app-shell poetheme-app-shell--sidebar-expanded" data-poetheme-app-shell>
     <aside id="<?php echo esc_attr( $sidebar_id ); ?>" class="poetheme-app-sidebar" aria-label="<?php esc_attr_e( 'Menu laterale del sito', 'poetheme' ); ?>">
@@ -26,7 +45,10 @@ $breadcrumbs_items = poetheme_get_breadcrumbs_items();
                 aria-expanded="true"
                 aria-controls="<?php echo esc_attr( $sidebar_id ); ?>"
             >
-                <span class="poetheme-app-sidebar__toggle-icon" aria-hidden="true"></span>
+                <svg class="poetheme-app-sidebar__toggle-icon" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+                    <rect x="4" y="5" width="16" height="14" rx="2" ry="2"></rect>
+                    <path d="M10 5v14"></path>
+                </svg>
                 <span class="screen-reader-text" data-poetheme-app-sidebar-toggle-label>
                     <?php esc_html_e( 'Comprimi menu laterale', 'poetheme' ); ?>
                 </span>
@@ -37,7 +59,7 @@ $breadcrumbs_items = poetheme_get_breadcrumbs_items();
             <?php
             poetheme_render_navigation_menu(
                 'primary',
-                'desktop',
+                'sidebar',
                 array(
                     'menu_class' => 'poetheme-app-sidebar__menu',
                 )
@@ -45,20 +67,64 @@ $breadcrumbs_items = poetheme_get_breadcrumbs_items();
             ?>
         </nav>
 
-        <?php poetheme_render_site_author_profile(); ?>
+        <?php poetheme_render_site_author_profile( array( 'context' => 'desktop' ) ); ?>
     </aside>
 
     <div class="poetheme-app-main">
-        <header class="poetheme-app-main-header">
-            <div class="poetheme-app-main-header__title-wrap">
-                <?php if ( '' !== trim( $title_text ) ) : ?>
-                    <h1 class="poetheme-app-page-title" itemprop="headline"><?php echo esc_html( $title_text ); ?></h1>
-                <?php endif; ?>
+        <div class="poetheme-app-mobile-bar">
+            <div class="poetheme-app-mobile-bar__brand">
+                <?php poetheme_the_logo(); ?>
             </div>
+            <button
+                type="button"
+                class="poetheme-app-mobile-toggle"
+                data-poetheme-app-mobile-toggle
+                aria-controls="<?php echo esc_attr( $mobile_drawer_id ); ?>"
+                aria-expanded="false"
+            >
+                <span aria-hidden="true">☰</span>
+                <span class="screen-reader-text"><?php esc_html_e( 'Apri menu mobile', 'poetheme' ); ?></span>
+            </button>
+        </div>
 
-            <?php if ( ! empty( $breadcrumbs_items ) ) : ?>
-                <nav class="poetheme-app-breadcrumbs" aria-label="<?php esc_attr_e( 'Breadcrumb', 'poetheme' ); ?>">
-                    <?php echo poetheme_get_breadcrumbs_markup( $breadcrumbs_items, poetheme_get_breadcrumbs_separator() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                </nav>
-            <?php endif; ?>
-        </header>
+        <?php if ( $show_title || ! empty( $breadcrumbs_items ) ) : ?>
+            <header class="poetheme-app-main-header">
+                <div class="poetheme-app-main-header__title-wrap">
+                <?php if ( $show_title ) : ?>
+                    <<?php echo tag_escape( $title_tag ); ?> class="<?php echo esc_attr( $title_classes ); ?>" itemprop="headline"><?php echo esc_html( $title_text ); ?></<?php echo tag_escape( $title_tag ); ?>>
+                <?php endif; ?>
+                </div>
+
+                <?php if ( ! empty( $breadcrumbs_items ) ) : ?>
+                    <nav class="poetheme-app-breadcrumbs" aria-label="<?php esc_attr_e( 'Breadcrumb', 'poetheme' ); ?>">
+                        <?php echo poetheme_get_breadcrumbs_markup( $breadcrumbs_items, poetheme_get_breadcrumbs_separator() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                    </nav>
+                <?php endif; ?>
+            </header>
+        <?php endif; ?>
+
+
+<div class="poetheme-app-mobile-overlay" data-poetheme-app-mobile-overlay hidden></div>
+<aside id="<?php echo esc_attr( $mobile_drawer_id ); ?>" class="poetheme-app-mobile-drawer" data-poetheme-app-mobile-drawer aria-label="<?php esc_attr_e( 'Menu mobile', 'poetheme' ); ?>" aria-hidden="true" hidden>
+    <div class="poetheme-app-mobile-drawer__header">
+        <div class="poetheme-app-mobile-drawer__brand">
+            <?php poetheme_the_logo(); ?>
+        </div>
+        <button type="button" class="poetheme-app-mobile-drawer__close" data-poetheme-app-mobile-close aria-controls="<?php echo esc_attr( $mobile_drawer_id ); ?>">
+            <span aria-hidden="true">×</span>
+            <span class="screen-reader-text"><?php esc_html_e( 'Chiudi menu mobile', 'poetheme' ); ?></span>
+        </button>
+    </div>
+    <nav class="poetheme-app-mobile-drawer__nav" aria-label="<?php esc_attr_e( 'Navigazione principale mobile', 'poetheme' ); ?>">
+        <?php
+        poetheme_render_navigation_menu(
+            'primary',
+            'mobile',
+            array(
+                'menu_class' => 'poetheme-app-mobile-drawer__menu',
+            )
+        );
+        ?>
+    </nav>
+    <?php poetheme_render_site_author_profile( array( 'context' => 'mobile' ) ); ?>
+</aside>


### PR DESCRIPTION
### Motivation
- Rendere il layout `style-9` (App Sidebar) conforme alle impostazioni esistenti di subheader (visibilità titolo/breadcrumb, `title_tag`, opzioni pagina come `hide_title`/`hide_breadcrumbs`) e risolvere comportamenti responsive e di accessibilità del menu laterale. 
- Evitare il clipping dei sottomenu multilivello nella sidebar desktop e fornire un menu mobile a comparsa da destra con overlay e gestione focus/ARIA. 
- Spostare il profilo autore nella posizione corretta su mobile senza duplicare la logica dati del profilo e aggiornare l'aspetto/markup del toggle per essere più semplice e accessibile.

### Description
- Template: aggiornato `template-parts/header/style-9.php` per usare `poetheme_get_subheader_options()`, `poetheme_subheader_should_display_title()`, validare `title_tag`, rispettare `show_title`/`hide_title` e `show_breadcrumbs`/`hide_breadcrumbs`, aggiungere markup per drawer mobile e mobile toggle, e sostituire l'icona toggle con SVG inline accessibile; il menu nella sidebar ora richiama `poetheme_render_navigation_menu( 'primary', 'sidebar', ... )` e il profilo autore viene renderizzato con contesto (`desktop`/`mobile`).
- Nav/menu: esteso `inc/nav-menu.php` (walker + helper) per supportare la variante `sidebar`, generare sottomenu in-flow (accordion) per desktop-sidebar e riutilizzare la logica mobile per i toggle sottomenu con gli attributi `aria-expanded`/`aria-controls`/`aria-hidden` fino ad almeno 3 livelli.
- Template tags: `inc/template-tags.php` rende ora `poetheme_render_site_author_profile()` parametrizzabile (`context` => `desktop|mobile`) e aggiunge classi distinte per posizionamento mobile/desktop.
- JS: rifatturato `assets/js/app-sidebar.js` per: persistenza collapse desktop (localStorage), aggiornamento ARIA e label dinamiche, accordion sidebar (variant `sidebar`), drawer mobile da destra con overlay, ESC, focus trap/restore e lock dello scroll; `inc/assets.php` aggiunge le stringhe localizzate per i label del drawer.
- CSS: completata e aggiornata la sezione `/* Header Style 9: App Sidebar */` in `style.css` per il layout desktop/RTL, toggle senza sfondo/bordo, sottomenu accordion in-flusso, drawer mobile da destra, visibilità sidebar su mobile e riduzione delle transizioni con `prefers-reduced-motion`.
- Versioning & docs: bump versione a `1.8.5` in `functions.php` e `style.css` e aggiunta delle note di rilascio + checklist audit Style 9 in `README.md`.
- File principali modificati: `template-parts/header/style-9.php`, `inc/nav-menu.php`, `inc/template-tags.php`, `assets/js/app-sidebar.js`, `style.css`, `inc/assets.php`, `functions.php`, `README.md`.

### Testing
- PHP lint: eseguito `php -l` su `template-parts/header/style-9.php`, `inc/nav-menu.php`, `inc/template-tags.php`, `inc/assets.php` e `functions.php`; tutti i file sono risultati senza errori di sintassi (successo). 
- JS static check: eseguito `node --check assets/js/app-sidebar.js` (e controllo su `assets/js/navigation.js` dopo adattamento); non sono stati rilevati errori di parsing (successo).
- Static checks: eseguito controllo di integrazione statica (`git diff --check`) e altri controlli locali; nessun errore bloccante rilevato (successo). 
- Nota runtime: non è presente una installazione WordPress eseguibile nel repo (`wp-config.php` assente), pertanto i test d'integrazione/visuali end-to-end (build attivo, rendering in browser, test con menu reali) non sono stati eseguiti qui e si raccomanda una verifica in ambiente WordPress 6.x reale per confermare comportamento con menu a 3+ livelli e impostazioni per pagina.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a298b9018188332a16b457a96152f50)