### PR TITLE
Style 9 App Sidebar: fix accordion, navigation conflict and header intro (v1.8.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'edi
 **Stato del tema:** Core Stable (release-ready).
 
 ## Changelog
+- 1.8.6: corretto **Style 9 – App Sidebar** con menu accordion verticale senza conflitto JS, rispetto completo delle impostazioni titolo/breadcrumb e nuova fascia descrittiva configurabile sopra il contenuto destro.
 - 1.8.4: aggiunto header layout **Style 9 – App Sidebar** con sidebar verticale collassabile, topbar contenuto con titolo/breadcrumb e profilo sito/autore.
 - 1.8.3: introdotta gerarchia tipografica default per heading H1–H6 frontend/editor.
 
@@ -59,6 +60,12 @@ Obiettivo: garantire la conformità a livello di tema (struttura, navigazione, f
 - Testi dei link/CTA descrittivi.
 - Alt text per immagini editoriali.
 
+
+## Note versione 1.8.6
+- `navigation.js` ignora esplicitamente la variante `sidebar`, lasciando il controllo dell’accordion laterale a `app-sidebar.js` senza handler hover/focusout desktop.
+- Il menu sinistro dello **Style 9 – App Sidebar** usa un accordion verticale multilivello con sottovoci nel flusso, indicatori indentati, stato attivo evidenziato e terzo livello visibile senza flyout laterale.
+- Il layout Style 9 rispetta `poetheme_subheader_should_display_title()`, `title_tag`, `hide_title`, `poetheme_subheader_should_display_breadcrumbs()` e `hide_breadcrumbs`.
+- Aggiunte opzioni admin per mostrare/nascondere e personalizzare la fascia descrittiva “Impostazioni testata” sopra la colonna contenuto destra del layout App Sidebar.
 
 ## Note versione 1.8.5
 - Corretto il layout **Style 9 – App Sidebar** affinché il titolo pagina rispetti `enable_subheader`, `show_title`, `hide_title` e il tag `title_tag` configurato.

--- a/assets/js/app-sidebar.js
+++ b/assets/js/app-sidebar.js
@@ -51,31 +51,48 @@
         menus.forEach(function (menu) {
             var items = menu.querySelectorAll('li.menu-item-has-children');
 
-            items.forEach(function (item) {
-                var trigger = item.querySelector(':scope > .poetheme-mobile-item-row > .poetheme-submenu-toggle');
-                var submenu = item.querySelector(':scope > [data-poetheme-submenu="true"]');
+            function setOpen(item, isOpen) {
+                var submenu = item.querySelector(':scope > [data-poetheme-sidebar-submenu]');
+                var toggles = item.querySelectorAll(':scope > .poetheme-sidebar-item-row > [data-poetheme-sidebar-submenu-toggle]');
 
-                if (!trigger || !submenu) {
+                if (!submenu || !toggles.length) {
                     return;
                 }
 
-                function setOpen(isOpen) {
-                    item.classList.toggle('is-open', isOpen);
-                    trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-                    submenu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+                item.classList.toggle('is-open', isOpen);
+                submenu.hidden = !isOpen;
+                submenu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+
+                toggles.forEach(function (toggle) {
+                    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+                });
+            }
+
+            items.forEach(function (item) {
+                var submenu = item.querySelector(':scope > [data-poetheme-sidebar-submenu]');
+                var toggles = item.querySelectorAll(':scope > .poetheme-sidebar-item-row > [data-poetheme-sidebar-submenu-toggle]');
+
+                if (!submenu || !toggles.length) {
+                    return;
                 }
 
-                setOpen(item.classList.contains('current-menu-ancestor') || item.classList.contains('current-menu-item'));
+                setOpen(item, item.classList.contains('current-menu-ancestor') || item.classList.contains('current-menu-parent') || item.classList.contains('current-menu-item'));
 
-                trigger.addEventListener('click', function () {
-                    setOpen(!item.classList.contains('is-open'));
+                toggles.forEach(function (toggle) {
+                    toggle.addEventListener('click', function (event) {
+                        if (toggle.tagName && toggle.tagName.toLowerCase() === 'a') {
+                            event.preventDefault();
+                        }
+
+                        setOpen(item, !item.classList.contains('is-open'));
+                    });
                 });
 
                 item.addEventListener('keydown', function (event) {
                     if (event.key === 'Escape' && item.classList.contains('is-open')) {
                         event.preventDefault();
-                        setOpen(false);
-                        trigger.focus();
+                        setOpen(item, false);
+                        toggles[0].focus();
                     }
                 });
             });

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -11,6 +11,10 @@
 
         menus.forEach(function (menu) {
             var variant = menu.getAttribute('data-variant') || 'desktop';
+            if (variant === 'sidebar') {
+                return;
+            }
+
             if (variant === 'mobile') {
                 setupMobileMenu(menu, navBreakpoint);
             } else {

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.8.5' );
+define( 'POETHEME_VERSION', '1.8.6' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -119,9 +119,12 @@ function poetheme_get_default_header_options() {
             'location_label' => '',
             'location_url'   => '',
         ),
-        'cta_text'      => __( 'Get Started', 'poetheme' ),
-        'cta_url'       => home_url( '/' ),
-        'social_links'  => $social_defaults,
+        'cta_text'                     => __( 'Get Started', 'poetheme' ),
+        'cta_url'                      => home_url( '/' ),
+        'social_links'                 => $social_defaults,
+        'show_app_header_intro'        => false,
+        'app_header_intro_title'       => __( 'Impostazioni testata', 'poetheme' ),
+        'app_header_intro_description' => __( 'Configura layout, top bar, call to action e profili social.', 'poetheme' ),
     );
 }
 
@@ -3756,6 +3759,20 @@ function poetheme_render_header_page() {
                         </td>
                     </tr>
                     <tr class="poetheme-field">
+                        <th scope="row" class="poetheme-field__label"><?php esc_html_e( 'Fascia descrittiva App Sidebar', 'poetheme' ); ?></th>
+                        <td class="poetheme-field__control">
+                            <label for="poetheme_header_show_app_header_intro">
+                                <input type="checkbox" id="poetheme_header_show_app_header_intro" name="poetheme_header[show_app_header_intro]" value="1" <?php checked( ! empty( $options['show_app_header_intro'] ) ); ?> aria-describedby="poetheme-header-app-intro-help" />
+                                <?php esc_html_e( 'Mostra fascia descrittiva nel layout App Sidebar.', 'poetheme' ); ?>
+                            </label>
+                            <p id="poetheme-header-app-intro-help" class="description poetheme-field__help"><?php esc_html_e( 'Queste impostazioni si applicano al layout App Sidebar e visualizzano una fascia sopra il contenuto destro.', 'poetheme' ); ?></p>
+                            <label for="poetheme_header_app_intro_title" class="poetheme-field__label"><?php esc_html_e( 'Titolo fascia', 'poetheme' ); ?></label>
+                            <input type="text" id="poetheme_header_app_intro_title" name="poetheme_header[app_header_intro_title]" value="<?php echo esc_attr( $options['app_header_intro_title'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Impostazioni testata', 'poetheme' ); ?>" />
+                            <label for="poetheme_header_app_intro_description" class="poetheme-field__label"><?php esc_html_e( 'Descrizione fascia', 'poetheme' ); ?></label>
+                            <textarea id="poetheme_header_app_intro_description" name="poetheme_header[app_header_intro_description]" class="large-text" rows="3" placeholder="<?php esc_attr_e( 'Configura layout, top bar, call to action e profili social.', 'poetheme' ); ?>"><?php echo esc_textarea( $options['app_header_intro_description'] ); ?></textarea>
+                        </td>
+                    </tr>
+                    <tr class="poetheme-field">
                         <th scope="row" class="poetheme-field__label"><?php esc_html_e( 'Icone social', 'poetheme' ); ?></th>
                         <td class="poetheme-field__control">
                             <p id="poetheme-header-social-help" class="description poetheme-field__help"><?php esc_html_e( 'Inserisci gli URL dei tuoi profili social per mostrarne le icone nella barra superiore.', 'poetheme' ); ?></p>
@@ -4271,8 +4288,9 @@ function poetheme_sanitize_header_options( $input ) {
         }
     }
 
-    $output['show_top_bar'] = ! empty( $input['show_top_bar'] );
-    $output['show_cta']     = ! empty( $input['show_cta'] );
+    $output['show_top_bar']          = ! empty( $input['show_top_bar'] );
+    $output['show_cta']              = ! empty( $input['show_cta'] );
+    $output['show_app_header_intro'] = ! empty( $input['show_app_header_intro'] );
 
     $output['top_bar_texts'] = array();
     foreach ( $defaults['top_bar_texts'] as $key => $default_value ) {
@@ -4301,6 +4319,9 @@ function poetheme_sanitize_header_options( $input ) {
 
     $output['cta_text'] = isset( $input['cta_text'] ) ? sanitize_text_field( $input['cta_text'] ) : '';
     $output['cta_url']  = isset( $input['cta_url'] ) ? esc_url_raw( $input['cta_url'] ) : '';
+
+    $output['app_header_intro_title']       = isset( $input['app_header_intro_title'] ) ? sanitize_text_field( $input['app_header_intro_title'] ) : $defaults['app_header_intro_title'];
+    $output['app_header_intro_description'] = isset( $input['app_header_intro_description'] ) ? sanitize_textarea_field( $input['app_header_intro_description'] ) : $defaults['app_header_intro_description'];
 
     $output['social_links'] = array();
     foreach ( poetheme_get_header_social_networks() as $key => $social ) {
@@ -4446,8 +4467,12 @@ function poetheme_get_header_options() {
     }
     $options['layout'] = $layout;
 
-    $options['show_top_bar'] = ! empty( $options['show_top_bar'] );
-    $options['show_cta']     = ! empty( $options['show_cta'] );
+    $options['show_top_bar']          = ! empty( $options['show_top_bar'] );
+    $options['show_cta']              = ! empty( $options['show_cta'] );
+    $options['show_app_header_intro'] = ! empty( $options['show_app_header_intro'] );
+
+    $options['app_header_intro_title']       = isset( $options['app_header_intro_title'] ) ? (string) $options['app_header_intro_title'] : $defaults['app_header_intro_title'];
+    $options['app_header_intro_description'] = isset( $options['app_header_intro_description'] ) ? (string) $options['app_header_intro_description'] : $defaults['app_header_intro_description'];
 
     return $options;
 }

--- a/inc/nav-menu.php
+++ b/inc/nav-menu.php
@@ -79,11 +79,8 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $parent_id = ! empty( $this->submenu_stack ) ? end( $this->submenu_stack ) : 0;
             $submenu_id = $parent_id && isset( $this->submenu_ids[ $parent_id ] ) ? $this->submenu_ids[ $parent_id ] : '';
 
-            if ( in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
+            if ( 'mobile' === $this->variant ) {
                 $classes = array( 'poetheme-submenu', 'pl-4', 'border-l', 'border-gray-200', 'space-y-2', 'mt-2' );
-                if ( 'sidebar' === $this->variant ) {
-                    $classes = array( 'poetheme-submenu', 'poetheme-sidebar-submenu' );
-                }
                 if ( $depth > 0 ) {
                     $classes[] = 'ml-2';
                 }
@@ -93,6 +90,26 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
                 $attributes .= " data-poetheme-submenu='true'";
                 $attributes .= " data-depth='" . esc_attr( (string) ( $depth + 1 ) ) . "'";
                 $attributes .= " aria-hidden='true'";
+
+                $output .= "\n{$indent}<ul{$attributes}>\n";
+                return;
+            }
+
+            if ( 'sidebar' === $this->variant ) {
+                $submenu_depth = $depth + 1;
+                $classes       = array(
+                    'poetheme-submenu',
+                    'poetheme-sidebar-submenu',
+                    'poetheme-sidebar-submenu--depth-' . $submenu_depth,
+                );
+
+                $attributes  = $submenu_id ? " id='" . esc_attr( $submenu_id ) . "'" : '';
+                $attributes .= " class='" . esc_attr( implode( ' ', $classes ) ) . "'";
+                $attributes .= " data-poetheme-submenu='true'";
+                $attributes .= " data-poetheme-sidebar-submenu='true'";
+                $attributes .= " data-depth='" . esc_attr( (string) $submenu_depth ) . "'";
+                $attributes .= " aria-hidden='true'";
+                $attributes .= ' hidden';
 
                 $output .= "\n{$indent}<ul{$attributes}>\n";
                 return;
@@ -167,7 +184,11 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
                 $this->submenu_stack[]                = $item->ID;
             }
 
-            $li_classes = array( 'poetheme-menu-item', 'relative' );
+            $li_classes = array( 'poetheme-menu-item' );
+
+            if ( 'sidebar' !== $this->variant ) {
+                $li_classes[] = 'relative';
+            }
 
             if ( 'desktop' === $this->variant && $has_children ) {
                 $li_classes[] = 'group';
@@ -247,10 +268,29 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
                     __( 'Apri il sottomenu di %s', 'poetheme' ),
                     $title
                 );
+                $toggle_attributes = array(
+                    'type'          => 'button',
+                    'class'         => 'poetheme-submenu-toggle inline-flex items-center justify-center text-gray-500 hover:text-blue-600 transition',
+                    'aria-expanded' => 'false',
+                    'aria-label'    => $toggle_label,
+                );
+
+                if ( $submenu_id ) {
+                    $toggle_attributes['aria-controls'] = $submenu_id;
+                }
+
+                if ( 'sidebar' === $this->variant ) {
+                    $toggle_attributes['data-poetheme-sidebar-submenu-toggle'] = 'true';
+                }
+
+                $toggle_attributes_markup = '';
+                foreach ( $toggle_attributes as $toggle_attribute => $toggle_value ) {
+                    $toggle_attributes_markup .= ' ' . $toggle_attribute . '="' . esc_attr( $toggle_value ) . '"';
+                }
+
                 $submenu_toggle = sprintf(
-                    '<button type="button" class="poetheme-submenu-toggle inline-flex items-center justify-center text-gray-500 hover:text-blue-600 transition" aria-expanded="false"%1$s aria-label="%2$s"><i data-lucide="chevron-down" class="poetheme-submenu-indicator w-4 h-4"></i></button>',
-                    $submenu_id ? ' aria-controls="' . esc_attr( $submenu_id ) . '"' : '',
-                    esc_attr( $toggle_label )
+                    '<button%1$s><i data-lucide="chevron-down" class="poetheme-submenu-indicator w-4 h-4"></i></button>',
+                    $toggle_attributes_markup
                 );
             }
 
@@ -258,8 +298,31 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
 
             $item_output  = $args->before;
             if ( $has_children && in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
-                $item_output .= '<div class="poetheme-mobile-item-row">';
+                $row_classes = array( 'poetheme-mobile-item-row' );
+                if ( 'sidebar' === $this->variant ) {
+                    $row_classes[] = 'poetheme-sidebar-item-row';
+                }
+                $item_output .= '<div class="' . esc_attr( implode( ' ', $row_classes ) ) . '">';
             }
+
+            if ( $has_children && 'sidebar' === $this->variant ) {
+                $atts['aria-expanded'] = 'false';
+                if ( $submenu_id ) {
+                    $atts['aria-controls'] = $submenu_id;
+                }
+                $atts['data-poetheme-sidebar-submenu-toggle'] = 'true';
+
+                $attributes = '';
+                foreach ( $atts as $attr => $value ) {
+                    if ( empty( $value ) ) {
+                        continue;
+                    }
+
+                    $value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+                    $attributes .= ' ' . $attr . '="' . $value . '"';
+                }
+            }
+
             $item_output .= '<a' . $attributes . '>';
             $item_output .= $args->link_before;
 
@@ -321,8 +384,18 @@ if ( ! class_exists( 'PoeTheme_Nav_Walker' ) ) {
             $classes = array( 'inline-flex', 'items-center', 'gap-2', 'transition', 'duration-150', 'ease-out' );
             $is_primary_layout = ( 'primary' === $this->layout );
 
-            if ( in_array( $this->variant, array( 'mobile', 'sidebar' ), true ) ) {
+            if ( 'mobile' === $this->variant ) {
                 $classes = array( 'flex', 'items-center', 'gap-2', 'flex-1', 'text-left', 'transition', 'duration-150' );
+                $classes[] = ( 0 === $depth ) ? 'text-base' : 'text-sm';
+                $classes[] = 'text-gray-800';
+                $classes[] = 'hover:text-blue-600';
+                $classes[] = 'py-1.5';
+                return implode( ' ', array_filter( $classes ) );
+            }
+
+            if ( 'sidebar' === $this->variant ) {
+                $classes = array( 'poetheme-sidebar-link', 'flex', 'items-center', 'gap-2', 'flex-1', 'text-left', 'transition', 'duration-150' );
+                $classes[] = 'poetheme-sidebar-link--depth-' . absint( $depth );
                 $classes[] = ( 0 === $depth ) ? 'text-base' : 'text-sm';
                 $classes[] = 'text-gray-800';
                 $classes[] = 'hover:text-blue-600';

--- a/languages/poetheme.pot
+++ b/languages/poetheme.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PoeTheme 1.6.0\n"
+"Project-Id-Version: PoeTheme 1.8.6\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-14 17:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -2481,4 +2481,36 @@ msgstr ""
 
 #: template-parts/header/style-9.php:43
 msgid "Navigazione principale"
+msgstr ""
+
+#: inc/admin/options.php template-parts/header/style-9.php
+msgid "Impostazioni testata"
+msgstr ""
+
+#: inc/admin/options.php template-parts/header/style-9.php
+msgid "Configura layout, top bar, call to action e profili social."
+msgstr ""
+
+#: inc/admin/options.php
+msgid "Fascia descrittiva App Sidebar"
+msgstr ""
+
+#: inc/admin/options.php
+msgid "Mostra fascia descrittiva nel layout App Sidebar."
+msgstr ""
+
+#: inc/admin/options.php
+msgid "Queste impostazioni si applicano al layout App Sidebar e visualizzano una fascia sopra il contenuto destro."
+msgstr ""
+
+#: inc/admin/options.php
+msgid "Titolo fascia"
+msgstr ""
+
+#: inc/admin/options.php
+msgid "Descrizione fascia"
+msgstr ""
+
+#: template-parts/header/style-9.php
+msgid "Introduzione impostazioni testata"
 msgstr ""

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.8.5
+Version: 1.8.6
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -1467,4 +1467,122 @@ body.poetheme-mobile-drawer-open {
   .poetheme-app-sidebar__profile--mobile {
     display: block;
   }
+}
+
+/* Style 9 App Sidebar accordion refinements */
+.poetheme-app-sidebar__nav .poetheme-sidebar-item-row {
+  gap: 0.35rem;
+  border-radius: 0.75rem;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-link {
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: 0.75rem;
+  color: var(--poetheme-menu-link-color, #374151);
+  font-weight: 600;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-1,
+.poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-2,
+.poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-3 {
+  min-height: 2.25rem;
+  padding-top: 0.45rem;
+  padding-bottom: 0.45rem;
+  color: #5f6b7a;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-2,
+.poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-3 {
+  font-size: 0.8125rem;
+}
+
+.poetheme-app-sidebar__nav .menu-item-has-children.is-open > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.poetheme-app-sidebar__nav .current-menu-item > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.poetheme-app-sidebar__nav .current-menu-parent > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.poetheme-app-sidebar__nav .current-menu-ancestor > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.poetheme-app-sidebar__nav .current_page_item > .poetheme-sidebar-item-row > .poetheme-sidebar-link {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--poetheme-menu-active-link-color, #2563eb);
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-item-row > .poetheme-submenu-toggle {
+  align-self: stretch;
+  min-height: 2.75rem;
+  color: #8a94a6;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu {
+  position: static;
+  display: none;
+  flex-direction: column;
+  gap: 0.15rem;
+  width: auto;
+  margin: 0.25rem 0 0 1.25rem;
+  padding: 0.25rem 0 0.35rem 0.85rem;
+  overflow: visible;
+  border-left: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: none;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu--depth-2 {
+  margin-left: 0.9rem;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu--depth-3 {
+  margin-left: 0.75rem;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu[hidden] {
+  display: none !important;
+}
+
+.poetheme-app-sidebar__nav .is-open > .poetheme-sidebar-submenu:not([hidden]) {
+  display: flex;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu .poetheme-menu-item {
+  position: relative;
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu .poetheme-menu-item::before {
+  position: absolute;
+  top: 1.1rem;
+  left: -0.95rem;
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.9);
+  content: "";
+}
+
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu .current-menu-item::before,
+.poetheme-app-sidebar__nav .poetheme-sidebar-submenu .current_page_item::before {
+  background: var(--poetheme-menu-active-link-color, #2563eb);
+}
+
+.poetheme-app-intro-strip {
+  width: 100%;
+  padding: 1.25rem clamp(1rem, 3vw, 3rem);
+  border-bottom: 1px solid var(--poetheme-app-border);
+  background: #f9fafb;
+}
+
+.poetheme-app-intro-strip__title {
+  margin: 0;
+  color: var(--poetheme-page-title-color, #111827);
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.poetheme-app-intro-strip__description {
+  max-width: 46rem;
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+  font-size: 0.925rem;
+  line-height: 1.6;
 }

--- a/template-parts/header/style-9.php
+++ b/template-parts/header/style-9.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $sidebar_id           = 'poetheme-app-sidebar';
 $mobile_drawer_id     = 'poetheme-app-mobile-drawer';
 $subheader_options    = poetheme_get_subheader_options();
+$header_options       = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
 $show_title           = poetheme_subheader_should_display_title();
 $show_breadcrumbs     = poetheme_subheader_should_display_breadcrumbs();
 $breadcrumbs_items    = $show_breadcrumbs ? poetheme_get_breadcrumbs_items() : array();
@@ -20,6 +21,17 @@ $title_tag            = isset( $subheader_options['title_tag'] ) ? strtolower( (
 $allowed_title_tags   = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
 $title_classes        = array_merge( array( 'poetheme-app-page-title' ), poetheme_get_subheader_title_classes() );
 $title_classes        = implode( ' ', array_map( 'sanitize_html_class', array_unique( $title_classes ) ) );
+$show_app_header_intro  = ! empty( $header_options['show_app_header_intro'] );
+$app_intro_title       = isset( $header_options['app_header_intro_title'] ) ? (string) $header_options['app_header_intro_title'] : '';
+$app_intro_description = isset( $header_options['app_header_intro_description'] ) ? (string) $header_options['app_header_intro_description'] : '';
+
+if ( '' === trim( $app_intro_title ) ) {
+    $app_intro_title = __( 'Impostazioni testata', 'poetheme' );
+}
+
+if ( '' === trim( $app_intro_description ) ) {
+    $app_intro_description = __( 'Configura layout, top bar, call to action e profili social.', 'poetheme' );
+}
 
 if ( ! in_array( $title_tag, $allowed_title_tags, true ) ) {
     $title_tag = 'h1';
@@ -86,6 +98,15 @@ if ( $show_title ) {
                 <span class="screen-reader-text"><?php esc_html_e( 'Apri menu mobile', 'poetheme' ); ?></span>
             </button>
         </div>
+
+        <?php if ( $show_app_header_intro ) : ?>
+            <section class="poetheme-app-intro-strip" aria-label="<?php esc_attr_e( 'Introduzione impostazioni testata', 'poetheme' ); ?>">
+                <p class="poetheme-app-intro-strip__title"><?php echo esc_html( $app_intro_title ); ?></p>
+                <?php if ( '' !== trim( $app_intro_description ) ) : ?>
+                    <p class="poetheme-app-intro-strip__description"><?php echo esc_html( $app_intro_description ); ?></p>
+                <?php endif; ?>
+            </section>
+        <?php endif; ?>
 
         <?php if ( $show_title || ! empty( $breadcrumbs_items ) ) : ?>
             <header class="poetheme-app-main-header">


### PR DESCRIPTION
### Motivation
- Prevent the desktop navigation initializer from interfering with the new App Sidebar accordion and ensure the sidebar menu has a single owner for its interaction state. 
- Make the Style 9 header respect the existing subheader visibility rules (`poetheme_subheader_should_display_title()`, `title_tag`, per-page `hide_title`) and breadcrumb visibility. 
- Replace flyout/hover behavior with a vertical accordion for the left sidebar so nested third-level items are visible in the document flow. 
- Add a configurable right-column intro strip (“Impostazioni testata”) for Style 9 that can be toggled and edited from the Header admin UI. 

### Description
- Updated `assets/js/navigation.js` to explicitly ignore menus with `data-variant=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a57c18b8c8332acf5d68cc774c91c)