### PR TITLE
App Sidebar (Style 9): remove duplicate page title + UI/UX & responsive polish

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -87,6 +87,33 @@ function poetheme_subheader_is_enabled() {
 }
 
 /**
+ * Determine whether the App Sidebar (Style 9) header layout is active.
+ *
+ * In this layout the page title lives inside the App Sidebar main header, so
+ * any in-content title output must be suppressed to avoid a duplicate title.
+ *
+ * @return bool
+ */
+function poetheme_is_app_sidebar_layout() {
+    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
+
+    return isset( $header_options['layout'] ) && 'style-9' === $header_options['layout'];
+}
+
+/**
+ * Determine whether the active header layer already renders the page title.
+ *
+ * Used by content templates to decide whether to print their own title. The
+ * App Sidebar always owns the title in its header; other layouts own it only
+ * when the subheader is enabled.
+ *
+ * @return bool
+ */
+function poetheme_header_owns_page_title() {
+    return poetheme_is_app_sidebar_layout() || poetheme_subheader_is_enabled();
+}
+
+/**
  * Determine if the current view should display the subheader title.
  *
  * @return bool
@@ -406,9 +433,7 @@ function poetheme_get_layout_container_classes( $additional = array(), $include_
  * @return string
  */
 function poetheme_get_main_classes() {
-    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
-
-    if ( isset( $header_options['layout'] ) && 'style-9' === $header_options['layout'] ) {
+    if ( poetheme_is_app_sidebar_layout() ) {
         $classes = array( 'poetheme-app-content' );
 
         if ( poetheme_page_has_no_top_padding() ) {

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@ get_header();
         <?php
         $showing_term_archive = is_category() || is_tag() || is_tax();
         $archive_description  = get_the_archive_description();
-        $display_archive_title = $showing_term_archive && ! poetheme_subheader_is_enabled();
+        $display_archive_title = $showing_term_archive && ! poetheme_header_owns_page_title();
 
         if ( $display_archive_title || $archive_description ) :
             ?>
@@ -35,7 +35,7 @@ get_header();
             <?php while ( have_posts() ) : the_post(); ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 focus-within:ring-2 focus-within:ring-indigo-500' ); ?> itemscope itemtype="https://schema.org/Article">
                     <header class="mb-4">
-                        <?php if ( is_singular() && ! poetheme_subheader_is_enabled() ) : ?>
+                        <?php if ( is_singular() && ! poetheme_header_owns_page_title() ) : ?>
                             <h1 class="poetheme-post-title text-3xl font-bold mb-2" itemprop="headline"><?php the_title(); ?></h1>
                         <?php else : ?>
                             <h2 class="text-2xl font-semibold mb-2" itemprop="headline">

--- a/page.php
+++ b/page.php
@@ -12,7 +12,7 @@ if ( have_posts() ) :
         the_post();
         ?>
         <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 space-y-6' ); ?> itemscope itemtype="https://schema.org/CreativeWork">
-            <?php if ( poetheme_should_display_page_title() && ! poetheme_subheader_is_enabled() ) : ?>
+            <?php if ( poetheme_should_display_page_title() && ! poetheme_header_owns_page_title() ) : ?>
                 <header class="space-y-2">
                     <h1 class="poetheme-page-title text-3xl font-bold" itemprop="headline"><?php the_title(); ?></h1>
                 </header>

--- a/single.php
+++ b/single.php
@@ -13,7 +13,7 @@ get_header();
             <?php the_post(); ?>
             <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 space-y-6' ); ?> itemscope itemtype="https://schema.org/Article">
                 <header class="space-y-2">
-                    <?php if ( ! poetheme_subheader_is_enabled() ) : ?>
+                    <?php if ( ! poetheme_header_owns_page_title() ) : ?>
                         <h1 class="poetheme-post-title text-3xl font-bold" itemprop="headline"><?php the_title(); ?></h1>
                     <?php endif; ?>
                     <?php poetheme_render_post_meta(); ?>

--- a/style.css
+++ b/style.css
@@ -1079,11 +1079,13 @@ body.poetheme-lightbox-open {
   box-shadow: none;
   color: var(--poetheme-menu-link-color, #374151);
   cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
 .poetheme-app-sidebar__toggle:hover,
 .poetheme-app-mobile-toggle:hover,
 .poetheme-app-mobile-drawer__close:hover {
+  background: rgba(37, 99, 235, 0.08);
   color: var(--poetheme-menu-active-link-color, #2563eb);
 }
 
@@ -1159,6 +1161,7 @@ body.poetheme-lightbox-open {
   border-radius: 0.75rem;
   color: var(--poetheme-menu-link-color, #374151);
   text-decoration: none;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
 .poetheme-app-sidebar__nav a:hover,
@@ -1247,6 +1250,11 @@ body.poetheme-lightbox-open {
   border-radius: 0.875rem;
   color: var(--poetheme-menu-link-color, #374151);
   text-decoration: none;
+  transition: background-color 150ms ease;
+}
+
+.poetheme-app-sidebar__profile-link:hover {
+  background: rgba(37, 99, 235, 0.06);
 }
 
 .poetheme-app-sidebar__profile-avatar {
@@ -1300,6 +1308,9 @@ body.poetheme-lightbox-open {
 }
 
 .poetheme-app-mobile-bar {
+  position: sticky;
+  top: 0;
+  z-index: 70;
   display: none;
   padding: 0.875rem clamp(1rem, 3vw, 3rem);
   border-bottom: 1px solid var(--poetheme-app-border);
@@ -1440,7 +1451,15 @@ body.poetheme-mobile-drawer-open {
   .poetheme-app-main,
   .poetheme-app-sidebar,
   .poetheme-app-mobile-overlay,
-  .poetheme-app-mobile-drawer {
+  .poetheme-app-mobile-drawer,
+  .poetheme-app-sidebar__nav a,
+  .poetheme-app-sidebar__nav .poetheme-sidebar-link,
+  .poetheme-app-sidebar__toggle,
+  .poetheme-app-mobile-toggle,
+  .poetheme-app-mobile-drawer__close,
+  .poetheme-app-sidebar__profile-link,
+  .poetheme-app-intro-menu a,
+  .poetheme-app-sidebar__nav .poetheme-submenu-indicator {
     transition: none;
   }
 }
@@ -1493,6 +1512,7 @@ body.poetheme-mobile-drawer-open {
   border-radius: 0.75rem;
   color: var(--poetheme-menu-link-color, #374151);
   font-weight: 600;
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
 .poetheme-app-sidebar__nav .poetheme-sidebar-link--depth-1,
@@ -1609,6 +1629,7 @@ body.poetheme-mobile-drawer-open {
   font-size: 0.925rem;
   font-weight: 700;
   text-decoration: none;
+  transition: color 150ms ease;
 }
 
 .poetheme-app-intro-menu a:hover,
@@ -1655,5 +1676,78 @@ body.poetheme-mobile-drawer-open {
 
   .poetheme-app-intro-menu {
     justify-content: flex-start;
+  }
+}
+
+/* Style 9 App Sidebar: UI/UX & responsive refinements */
+.poetheme-app-sidebar__nav .poetheme-submenu-indicator {
+  transition: transform 180ms ease;
+}
+
+/* Smooth, subtle scrollbar for the scrollable sidebar navigation. */
+.poetheme-app-sidebar__nav {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.5) transparent;
+}
+
+.poetheme-app-sidebar__nav::-webkit-scrollbar {
+  width: 8px;
+}
+
+.poetheme-app-sidebar__nav::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.poetheme-app-sidebar__nav:hover {
+  scrollbar-color: rgba(148, 163, 184, 0.7) transparent;
+}
+
+.poetheme-app-sidebar__nav:hover::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.6);
+}
+
+/* Clearer wayfinding: leading accent on the active top-level item. */
+.poetheme-app-sidebar__nav .current-menu-item > a,
+.poetheme-app-sidebar__nav .current_page_item > a,
+.poetheme-app-sidebar__nav .current-menu-item > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.poetheme-app-sidebar__nav .current_page_item > .poetheme-sidebar-item-row > .poetheme-sidebar-link {
+  box-shadow: inset 0.1875rem 0 0 0 var(--poetheme-menu-active-link-color, #2563eb);
+}
+
+.rtl .poetheme-app-sidebar__nav .current-menu-item > a,
+.rtl .poetheme-app-sidebar__nav .current_page_item > a,
+.rtl .poetheme-app-sidebar__nav .current-menu-item > .poetheme-sidebar-item-row > .poetheme-sidebar-link,
+.rtl .poetheme-app-sidebar__nav .current_page_item > .poetheme-sidebar-item-row > .poetheme-sidebar-link {
+  box-shadow: inset -0.1875rem 0 0 0 var(--poetheme-menu-active-link-color, #2563eb);
+}
+
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .current-menu-item > a,
+.poetheme-app-shell.is-sidebar-collapsed .poetheme-app-sidebar__nav .current_page_item > a {
+  box-shadow: none;
+}
+
+/* Let the main header title and breadcrumbs wrap gracefully when space is tight. */
+.poetheme-app-main-header {
+  flex-wrap: wrap;
+}
+
+.poetheme-app-main-header__title-wrap {
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
+.poetheme-app-page-title {
+  overflow-wrap: anywhere;
+}
+
+/* Tablet: trim the sidebar so the content keeps comfortable room. */
+@media (min-width: 768px) and (max-width: 1023.98px) {
+  .poetheme-app-shell {
+    --poetheme-app-sidebar-width: 224px;
+  }
+
+  .poetheme-app-main-header {
+    padding-top: 1.5rem;
   }
 }

--- a/template-parts/archive/header.php
+++ b/template-parts/archive/header.php
@@ -28,7 +28,12 @@ if ( '' === trim( $description ) ) {
 
 $show_title = true;
 
-if ( poetheme_subheader_is_enabled() && poetheme_subheader_should_display_title() ) {
+if ( poetheme_is_app_sidebar_layout() ) {
+    // The App Sidebar renders the archive title in its own main header.
+    $show_title = false;
+}
+
+if ( $show_title && poetheme_subheader_is_enabled() && poetheme_subheader_should_display_title() ) {
     $subheader_options = poetheme_get_subheader_options();
     $title_tag         = isset( $subheader_options['title_tag'] ) ? strtolower( $subheader_options['title_tag'] ) : 'h1';
 

--- a/template-parts/header/style-9.php
+++ b/template-parts/header/style-9.php
@@ -40,7 +40,21 @@ if ( $show_title ) {
     }
 }
 ?>
-<div class="poetheme-app-shell poetheme-app-shell--sidebar-expanded" data-poetheme-app-shell>
+<div id="poetheme-app-shell" class="poetheme-app-shell poetheme-app-shell--sidebar-expanded" data-poetheme-app-shell>
+    <script>
+        /* Apply the stored collapsed state before paint to avoid a layout flash. */
+        ( function () {
+            try {
+                if ( window.localStorage.getItem( 'poethemeAppSidebarCollapsed' ) === '1' ) {
+                    var shell = document.getElementById( 'poetheme-app-shell' );
+                    if ( shell ) {
+                        shell.classList.add( 'is-sidebar-collapsed' );
+                        shell.classList.remove( 'poetheme-app-shell--sidebar-expanded' );
+                    }
+                }
+            } catch ( error ) {}
+        }() );
+    </script>
     <aside id="<?php echo esc_attr( $sidebar_id ); ?>" class="poetheme-app-sidebar" aria-label="<?php esc_attr_e( 'Menu laterale del sito', 'poetheme' ); ?>">
         <div class="poetheme-app-sidebar__header">
             <div class="poetheme-app-sidebar__brand">

--- a/template-parts/header/style-9.php
+++ b/template-parts/header/style-9.php
@@ -13,7 +13,9 @@ $sidebar_id           = 'poetheme-app-sidebar';
 $mobile_drawer_id     = 'poetheme-app-mobile-drawer';
 $subheader_options    = poetheme_get_subheader_options();
 $header_options       = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
-$show_title           = poetheme_subheader_should_display_title();
+$show_title           = poetheme_subheader_is_enabled()
+    ? poetheme_subheader_should_display_title()
+    : poetheme_should_display_page_title();
 $show_breadcrumbs     = poetheme_subheader_should_display_breadcrumbs();
 $breadcrumbs_items    = $show_breadcrumbs ? poetheme_get_breadcrumbs_items() : array();
 $title_text           = '';

--- a/templates/page-two-columns-left.php
+++ b/templates/page-two-columns-left.php
@@ -26,7 +26,7 @@ if ( have_posts() ) :
 
             <div class="lg:col-span-10 space-y-6">
                 <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 space-y-6' ); ?> itemscope itemtype="https://schema.org/CreativeWork">
-                    <?php if ( poetheme_should_display_page_title() && ! poetheme_subheader_is_enabled() ) : ?>
+                    <?php if ( poetheme_should_display_page_title() && ! poetheme_header_owns_page_title() ) : ?>
                         <header class="space-y-2">
                             <h1 class="poetheme-page-title text-3xl font-bold" itemprop="headline"><?php the_title(); ?></h1>
                         </header>

--- a/templates/page-two-columns-right.php
+++ b/templates/page-two-columns-right.php
@@ -15,7 +15,7 @@ if ( have_posts() ) :
         <div class="grid gap-8 lg:grid-cols-12">
             <div class="lg:col-span-10 space-y-6">
                 <article id="post-<?php the_ID(); ?>" <?php post_class( 'bg-white rounded-lg shadow-sm p-6 space-y-6' ); ?> itemscope itemtype="https://schema.org/CreativeWork">
-                    <?php if ( poetheme_should_display_page_title() && ! poetheme_subheader_is_enabled() ) : ?>
+                    <?php if ( poetheme_should_display_page_title() && ! poetheme_header_owns_page_title() ) : ?>
                         <header class="space-y-2">
                             <h1 class="poetheme-page-title text-3xl font-bold" itemprop="headline"><?php the_title(); ?></h1>
                         </header>


### PR DESCRIPTION
## Sommario
Interventi sul layout header **Style 9 – App Sidebar**: eliminazione del doppio titolo nelle pagine e rifinitura di dettagli, responsive e UX/UI mantenendo il design attuale. Due commit indipendenti.

> Nota: questi commit sono successivi al merge della #66 (1.9.0); questa PR contiene **solo** le modifiche all'App Sidebar.

## 🐛 Doppio titolo rimosso
Nel layout App Sidebar il titolo è reso nell'header dell'app (`.poetheme-app-main-header`), ma i template di contenuto lo stampavano di nuovo → doppio titolo. La vecchia condizione lo nascondeva solo con il *subheader* attivo, lasciando scoperti altri casi.

- Nuovi helper in `inc/template-tags.php`: `poetheme_is_app_sidebar_layout()` e `poetheme_header_owns_page_title()`.
- Soppressione del titolo in-content quando l'header lo possiede già, in **tutti** i template: `page.php`, `single.php`, `index.php`, `templates/page-two-columns-*.php`, `template-parts/archive/header.php`.
- Lo Style 9 ora mostra il titolo nel proprio header **anche con subheader disattivato**, così il titolo non si perde mai → sempre **un solo titolo**.

## ✨ Rifiniture UI/UX e responsive (design invariato)
- Transizioni fluide su link sidebar/drawer, toggle, profilo e menu intro; coperte da `prefers-reduced-motion`.
- Barra mobile **sticky**: il toggle resta raggiungibile durante lo scroll.
- Scrollbar custom sottile per la navigazione laterale.
- Indicatore voce **attiva** (accento laterale, nascosto da collassata, RTL-aware).
- Header che va a capo con grazia; titolo che non sfora su viewport strette.
- Trattamento **tablet** dedicato (768–1023px) con sidebar più stretta.
- Niente flash al caricamento: lo stato "compressa" viene applicato prima del paint.

## Verifica
- `php -l` verde su tutti i file toccati; parentesi CSS bilanciate; nessuna nuova classe Tailwind (nessun rebuild).
- **Test manuali consigliati in WordPress**: pagina/articolo/archivio con Style 9 → titolo singolo; comprimi/espandi sidebar + reload (assenza flash); drawer mobile; vista tablet; tastiera e reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ)_