### PR TITLE
Apply fonts/sizes to headings on front end; preview text scaling; Classic header background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.23.0
+- **Font e dimensioni ora applicati ai titoli (H1–H6) sul front-end:** le regole di font/dimensione
+  venivano battute dalla regola base del tema (`:where(h1):not([class*="-font-size"])`, specificità
+  superiore). Ora le regole di font (famiglia, dimensione, raggio, spaziatura) sono "scoped" sotto
+  `body.poetheme-has-font-settings`, così vincono correttamente. Anche le **liste** e il **testo del
+  contenuto** ricevono la dimensione impostata.
+- **Anteprima dello Studio:** la dimensione del testo ora scala anche paragrafi ed elenchi del
+  contenuto d'esempio (prima solo il paragrafo introduttivo).
+- **Testata Classic:** lo sfondo della testata viene ora applicato in modo garantito (stile inline
+  che segue colori/palette), così il colore impostato è sempre rispettato.
+
 ## 1.22.0
 - **Layout pieno/box ora funziona con le palette:** il generatore non forza più `layout_mode` su
   ogni palette, quindi la scelta “Larghezza piena / Box” (in Globale o nello Studio avanzato) viene

--- a/assets/js/style-studio.js
+++ b/assets/js/style-studio.js
@@ -341,7 +341,7 @@
         frame.appendChild(hero);
 
         /* Article card with diverse content */
-        var card = el('div', { className: 'poetheme-studio__pv-card', style: 'background:' + colors.content_background_color });
+        var card = el('div', { className: 'poetheme-studio__pv-card', style: 'background:' + colors.content_background_color + ';font-size:' + type.base + 'rem' });
 
         var underline = ( colors.content_link_underline === true || colors.content_link_underline === '1' || colors.content_link_underline === 1 );
         var linkStyle = 'color:' + colors.content_link_color + ';text-decoration:' + ( underline ? 'underline' : 'none' );

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.22.0' );
+define( 'POETHEME_VERSION', '1.23.0' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/fonts.php
+++ b/inc/admin/options/fonts.php
@@ -625,6 +625,35 @@ function poetheme_build_font_stack( $font_slug, $fallback, $available_fonts = nu
 }
 
 /**
+ * Scope a list of CSS selectors under the font-settings body class so the rules
+ * win over the theme's base heading styles (which use `:where(...):not([class*="-font-size"])`,
+ * specificity (0,1,0), higher than a bare `h1`).
+ *
+ * @param array $selectors Raw selectors (e.g. h1, body, main li).
+ * @return string Comma-joined scoped selector list.
+ */
+function poetheme_scope_font_selectors( $selectors ) {
+    $scoped = array();
+
+    foreach ( (array) $selectors as $selector ) {
+        $selector = trim( $selector );
+        if ( '' === $selector ) {
+            continue;
+        }
+
+        if ( 'body' === $selector ) {
+            $scoped[] = 'body.poetheme-has-font-settings';
+        } elseif ( 0 === strpos( $selector, 'body ' ) ) {
+            $scoped[] = 'body.poetheme-has-font-settings ' . substr( $selector, 5 );
+        } else {
+            $scoped[] = 'body.poetheme-has-font-settings ' . $selector;
+        }
+    }
+
+    return implode( ',', $scoped );
+}
+
+/**
  * Prepare font styles (font-face rules and CSS stacks).
  *
  * @return array
@@ -704,7 +733,7 @@ function poetheme_prepare_font_styles() {
             $selectors = array_filter( array_map( 'trim', (array) $field['selectors'] ) );
 
             if ( $selectors ) {
-                $css_rules .= implode( ',', $selectors ) . '{font-family:' . $stack . ';}';
+                $css_rules .= poetheme_scope_font_selectors( $selectors ) . '{font-family:' . $stack . ';}';
             }
         }
     }
@@ -737,7 +766,7 @@ function poetheme_prepare_font_styles() {
             continue;
         }
 
-        $size_rules .= implode( ',', $size_selectors ) . '{font-size:' . poetheme_format_number_for_css( $size_val ) . 'rem;}';
+        $size_rules .= poetheme_scope_font_selectors( $size_selectors ) . '{font-size:' . poetheme_format_number_for_css( $size_val ) . 'rem;}';
     }
 
     $radius_rules = '';
@@ -774,7 +803,7 @@ function poetheme_prepare_font_styles() {
 
         $unit = ! empty( $field['border_radius']['unit'] ) ? $field['border_radius']['unit'] : 'px';
 
-        $radius_rules .= implode( ',', $radius_selectors ) . '{border-radius:' . poetheme_format_number_for_css( $radius_val ) . $unit . ';}';
+        $radius_rules .= poetheme_scope_font_selectors( $radius_selectors ) . '{border-radius:' . poetheme_format_number_for_css( $radius_val ) . $unit . ';}';
     }
 
     $spacing_rules = '';
@@ -811,7 +840,7 @@ function poetheme_prepare_font_styles() {
             continue;
         }
 
-        $spacing_rules .= implode( ',', $spacing_selectors ) . '{' . $declarations . ';}';
+        $spacing_rules .= poetheme_scope_font_selectors( $spacing_selectors ) . '{' . $declarations . ';}';
     }
 
     $global_rules = '';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -842,6 +842,35 @@ function poetheme_render_site_author_profile( $args = array() ) {
  *
  * @return array
  */
+/**
+ * Build the inline background-color style for the site header.
+ *
+ * Guarantees the header background follows the resolved color options (theme or
+ * active palette) regardless of CSS cascade/specificity. Returns an empty string
+ * when no explicit background should be set.
+ *
+ * @return string e.g. ' style="background-color:#fff;"' or ''.
+ */
+function poetheme_get_header_inline_style() {
+    if ( ! function_exists( 'poetheme_get_color_options' ) ) {
+        return '';
+    }
+
+    $colors = poetheme_get_color_options();
+
+    if ( ! empty( $colors['header_background_transparent'] ) ) {
+        return ' style="background-color:transparent !important;"';
+    }
+
+    $background = ! empty( $colors['header_background_color'] ) ? $colors['header_background_color'] : '';
+
+    if ( '' === $background ) {
+        return '';
+    }
+
+    return ' style="background-color:' . esc_attr( $background ) . ' !important;"';
+}
+
 function poetheme_get_header_context() {
     $options = poetheme_get_header_options();
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.22.0
+Version: 1.23.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme

--- a/template-parts/header/style-1.php
+++ b/template-parts/header/style-1.php
@@ -64,7 +64,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-1 poetheme-header poetheme-header--style-1 relative"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >


### PR DESCRIPTION
## Sommario
Corregge l’applicazione di **font/dimensioni ai titoli** sul front-end, lo **scaling del testo nell’anteprima** e lo **sfondo della testata Classic**. Bump a 1.23.0.

> Nota: successiva al merge della #83.

## 🎯 #H: font e dimensioni non applicati sul front-end — **causa trovata**
La regola base del tema in `style.css` è:
```css
:where(h1):not([class*="-font-size"]), … { font-size: clamp(...) }
```
`:where()` ha specificità 0, ma `:not([class*="-font-size"])` aggiunge un selettore di attributo → **specificità (0,1,0)**. Le regole del sistema font erano emesse come `h1{font-size:…}` → **(0,0,1)**, quindi **perdevano** contro la base. Risultato: titoli (e liste/testo) ignoravano la tipografia della palette sul front-end (mentre l’anteprima JS, che usa stili inline, funzionava).

**Fix:** nuova `poetheme_scope_font_selectors()` che prefissa le regole font (famiglia, dimensione, raggio, spaziatura) con `body.poetheme-has-font-settings` → specificità ≥ (0,1,1), così **vincono** sulla base. La classe è sempre presente con una palette attiva. Ora H1–H6, **elenchi** e **testo del contenuto** ricevono famiglia e dimensione corrette.

## 🖼️ Anteprima Studio: testo/liste non scalavano
Solo il paragrafo introduttivo aveva una dimensione esplicita. Ora la **card di anteprima** imposta `font-size` = dimensione base scelta, così paragrafi, **elenchi puntati/numerati** e citazione scalano con la dimensione del testo.

## 🧭 Testata Classic (style-1): sfondo garantito
Anche se `.poetheme-header{background-color:var(--poetheme-header-background-color)}` dovrebbe bastare, per la Classic ho aggiunto uno **stile inline `!important`** sul `<header>` (`poetheme_get_header_inline_style()`), derivato dai colori risolti (tema/palette). Così lo sfondo della testata segue sempre il colore impostato, indipendentemente da cascade/var. Rispetta anche l’opzione “Testata trasparente”.

## Note
- Lo scoping vale quando una palette è attiva (classe presente) — il caso d’uso corrente. Il vecchio percorso “solo dimensioni senza palette/font” era già non funzionante per lo stesso motivo di specificità, quindi nessuna regressione.
- Ho iniziato dalla **Classic** come richiesto; le altre testate (style-2…9) le ottimizzo allo stesso modo nei prossimi passi se confermi l’approccio.

## Verifica
- `php -l` verde (fonts, template-tags, style-1); `node --check` JS ok.
- **Test**: con palette attiva, imposta font/dimensione titoli → gli H cambiano sul front-end; un elenco cambia dimensione; nell’anteprima cambia anche il corpo testo/liste; sulla testata Classic imposta uno sfondo → cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ)_