### PR TITLE
Fix heading font override (title fallback) + header background on all headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.26.0
+- **Font dei titoli ora rispettato (fix):** gli elementi specifici (titolo pagina/articolo/categoria,
+  intestazioni footer, CTA, ecc.) senza un font dedicato non vengono più forzati sul font di sistema:
+  ereditano il font dei titoli/testo. Prima la regola più specifica (es. `.poetheme-page-title`)
+  sovrascriveva il font scelto per gli H.
+- **Sfondo testata applicato su tutte le testate:** lo stile inline garantito dello sfondo testata
+  (che segue colori/palette) è stato esteso a tutte le testate standard (style 1–8), non solo la
+  Classic.
+
 ## 1.25.0
 - **Fix accesso a Style Studio:** la pagina era diventata inaccessibile (“Non hai il permesso…”)
   perché rimossa da `$submenu`. Ora resta registrata e accessibile (dalla galleria); il link nel

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.25.0' );
+define( 'POETHEME_VERSION', '1.26.0' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/fonts.php
+++ b/inc/admin/options/fonts.php
@@ -729,7 +729,16 @@ function poetheme_prepare_font_styles() {
             $heading_stack = $stack;
         }
 
-        if ( ! empty( $field['selectors'] ) ) {
+        // Only emit a font-family rule for an element when it has its OWN font
+        // selected. body_font / heading_font are the base fonts and always emit
+        // (falling back to the system stack). Secondary elements (titles, footer
+        // headings, CTA, etc.) with no specific font are left to inherit from the
+        // heading/body rules instead of being forced onto the fallback stack —
+        // otherwise their more specific selector (e.g. .poetheme-page-title) would
+        // override the chosen heading font.
+        $is_primary_font = in_array( $key, array( 'body_font', 'heading_font' ), true );
+
+        if ( ! empty( $field['selectors'] ) && ( '' !== $value || $is_primary_font ) ) {
             $selectors = array_filter( array_map( 'trim', (array) $field['selectors'] ) );
 
             if ( $selectors ) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.25.0
+Version: 1.26.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme

--- a/template-parts/header/style-2.php
+++ b/template-parts/header/style-2.php
@@ -79,7 +79,7 @@ $mobile_right_items = $right_location ? poetheme_get_navigation_menu_items( $rig
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-2 poetheme-header poetheme-header--style-2"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >

--- a/template-parts/header/style-3.php
+++ b/template-parts/header/style-3.php
@@ -83,7 +83,7 @@ $search_url      = get_search_link();
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-3 poetheme-header poetheme-header--style-3"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >

--- a/template-parts/header/style-4.php
+++ b/template-parts/header/style-4.php
@@ -75,7 +75,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-4 poetheme-header poetheme-header--style-4"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >

--- a/template-parts/header/style-5.php
+++ b/template-parts/header/style-5.php
@@ -64,7 +64,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-5 poetheme-header poetheme-header--style-5"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >

--- a/template-parts/header/style-6.php
+++ b/template-parts/header/style-6.php
@@ -64,7 +64,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-6 poetheme-header poetheme-header--style-6"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false, scrolled: false }"
     @scroll.window="scrolled = window.scrollY > 30"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"

--- a/template-parts/header/style-7.php
+++ b/template-parts/header/style-7.php
@@ -64,7 +64,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-7 poetheme-header poetheme-header--style-7"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >

--- a/template-parts/header/style-8.php
+++ b/template-parts/header/style-8.php
@@ -64,7 +64,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
 ?>
 <header
     class="poetheme-site-header poetheme-site-header--style-8 poetheme-header poetheme-header--style-8"
-    role="banner"
+    role="banner"<?php echo poetheme_get_header_inline_style(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value escaped via esc_attr() inside the helper. ?>
     x-data="{ mobileOpen: false }"
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >


### PR DESCRIPTION
## Sommario
Due fix mirati dalle tue segnalazioni. Bump a 1.26.0.

> Nota: successiva al merge della #86.

## 🔤 Font dei titoli non applicato — **causa trovata (la tua intuizione era giusta)**
La regola che vinceva era proprio:
```css
body.poetheme-has-font-settings .poetheme-page-title { font-family: system-ui, … }
```
Veniva emessa perché il **font specifico del titolo pagina** (e di altri elementi: titolo articolo/categoria, intestazioni footer, CTA, ecc.) è **vuoto** → il sistema generava comunque una regola con il **fallback di sistema**, e quel selettore (`.poetheme-page-title`, specificità più alta) **sovrascriveva** il font scelto per gli `h1..h6`.

**Fix:** ora la regola `font-family` viene emessa **solo** se l’elemento ha un font dedicato. `body_font`/`heading_font` restano sempre (base), mentre gli elementi secondari senza font **ereditano** il font dei titoli/testo invece di essere forzati sul font di sistema. Quindi il titolo pagina/articolo prende il font dei titoli scelto. ✓

## 🧭 Sfondo testata applicato su tutte le testate
Lo **stile inline garantito** dello sfondo testata (che segue i colori risolti / palette attiva, con `!important`) era solo sulla Classic: l’ho esteso a **tutte le testate standard (style 1–8)**. Così il colore di sfondo della testata è sempre applicato sul front-end, a prescindere dalla cascade.

## Sul “non viene memorizzato” (sfondo testata)
Ho verificato per intero la catena di salvataggio (override → `array_merge` → `poetheme_sanitize_color_options` mantiene l’hex valido → `array_intersect_key` conserva la chiave → salvato in `overrides.colors` → ricaricato in modifica). A livello di codice **viene memorizzato correttamente**. Due cose da verificare lato uso:
1. Dopo aver modificato lo sfondo testata, usa **“Aggiorna e applica”** (o applica la palette) — con solo “Aggiorna” il front-end cambia solo se quella palette è già **quella attiva**.
2. Se riaprendo la palette in Modifica il campo è ancora bianco, **esporta** quella palette e incollami il JSON: vedo subito se `header_background_color` è in `overrides.colors`.

## Verifica
- `php -l` verde (fonts + style 1–9); test header.
- **Test**: imposta un font titoli in una palette attiva → il titolo della pagina/articolo cambia font; imposta uno sfondo testata e applica → la barra cambia colore su tutte le testate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ)_