### PR TITLE
Palette-manage footer & mobile menu; remove hardcoded header borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.28.0
+- **Footer gestito dalla palette:** rimosse le classi hardcoded (`bg-white`, `bg-gray-100`,
+  `border-t`) dal footer. La barra dei crediti ora segue lo sfondo, il testo e i link del footer
+  della palette (niente più fondo bianco in modalità scura).
+- **Bordi testate rimossi:** eliminati i bordi hardcoded `border-t`/`border-b` (non gestiti dalla
+  palette) da tutte le testate (style 1–9).
+- **Menu mobile (smartphone) gestito dalla palette:** il pannello a scomparsa è ora una superficie di
+  contenuto (sfondo = sfondo contenuto, testo/titolo/chiudi = colori contenuto, link attivi = colore
+  link), così resta sempre leggibile a prescindere dai colori del menu in testata.
+
 ## 1.27.0
 - **Fix sfondo testata (e tutti gli override avanzati) non memorizzati:** modificando una palette con
   bucket di override vuoti (es. i preset), `wp_localize_script` li passava come array JS; aggiungendo

--- a/footer.php
+++ b/footer.php
@@ -25,11 +25,9 @@
         }
     }
     $color_options = poetheme_get_color_options();
-    $footer_widget_classes = array( 'poetheme-footer-widgets', 'bg-gray-100', 'border-t', 'border-gray-200' );
-
-    if ( ! empty( $color_options['footer_widget_background_transparent'] ) ) {
-        $footer_widget_classes = array( 'poetheme-footer-widgets' );
-    }
+    // Background and borders are driven by the active palette (see head-output),
+    // not by hardcoded utility classes that would override it (e.g. in dark mode).
+    $footer_widget_classes = array( 'poetheme-footer-widgets' );
     ?>
     <?php if ( $show_footer && $has_widgets ) : ?>
     <aside class="<?php echo esc_attr( implode( ' ', $footer_widget_classes ) ); ?>" aria-label="<?php esc_attr_e( 'Footer widgets', 'poetheme' ); ?>">
@@ -89,7 +87,7 @@
     <?php endif; ?>
 
     <?php if ( $show_footer && $show_credits ) : ?>
-    <footer class="poetheme-footer-credits bg-white border-t border-gray-200" role="contentinfo">
+    <footer class="poetheme-footer-credits" role="contentinfo">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-6', 'flex', 'flex-col', 'gap-4', 'md:flex-row', 'md:items-center', 'md:justify-between' ) ) ); ?>">
             <div class="poetheme-footer-credits__content text-sm text-gray-600">
                 <?php if ( $credits_text ) : ?>

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.27.0' );
+define( 'POETHEME_VERSION', '1.28.0' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/head-output.php
+++ b/inc/head-output.php
@@ -192,6 +192,15 @@ function poetheme_get_design_settings_css() {
     $styles .= 'body.poetheme-has-color-settings .poetheme-nav--location-primary a,body.poetheme-has-color-settings .poetheme-nav--location-primary-left a,body.poetheme-has-color-settings .poetheme-nav--location-primary-right a{color:var(--poetheme-menu-link-color) !important;background-color:var(--poetheme-menu-link-background) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-nav--location-primary .current-menu-item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary .current_page_item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary a:hover,body.poetheme-has-color-settings .poetheme-nav--location-primary a:focus,body.poetheme-has-color-settings .poetheme-nav--location-primary-left .current-menu-item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary-left .current_page_item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary-left a:hover,body.poetheme-has-color-settings .poetheme-nav--location-primary-left a:focus,body.poetheme-has-color-settings .poetheme-nav--location-primary-right .current-menu-item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary-right .current_page_item > a,body.poetheme-has-color-settings .poetheme-nav--location-primary-right a:hover,body.poetheme-has-color-settings .poetheme-nav--location-primary-right a:focus{color:var(--poetheme-menu-active-link-color) !important;background-color:var(--poetheme-menu-active-background) !important;}';
 
+    // Mobile slide-in menu: the panel is a content surface, so it follows the
+    // content background/text colors (the header menu colors are tuned for the
+    // header bar and could be unreadable on the panel).
+    $styles .= 'body.poetheme-has-color-settings .poetheme-mobile-panel{background-color:var(--poetheme-content-background-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-mobile-panel__title{color:var(--poetheme-content-strong-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-mobile-panel__header button{color:var(--poetheme-content-text-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-nav a:not(.poetheme-cta-button){color:var(--poetheme-content-text-color) !important;background-color:transparent !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-nav .current-menu-item > a:not(.poetheme-cta-button),body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-nav .current_page_item > a:not(.poetheme-cta-button),body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-nav a:not(.poetheme-cta-button):hover,body.poetheme-has-color-settings .poetheme-mobile-panel .poetheme-nav a:not(.poetheme-cta-button):focus{color:var(--poetheme-content-link-color) !important;}';
+
     $styles .= 'body.poetheme-has-color-settings .poetheme-cta-button{background-color:var(--poetheme-cta-background-color) !important;color:var(--poetheme-cta-text-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-cta-button:hover,body.poetheme-has-color-settings .poetheme-cta-button:focus{background-color:var(--poetheme-cta-background-color) !important;color:var(--poetheme-cta-text-color) !important;}';
 
@@ -267,6 +276,12 @@ function poetheme_get_design_settings_css() {
     }
     $styles .= 'body.poetheme-has-color-settings .poetheme-footer-widgets a{color:var(--poetheme-footer-widget-link-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-footer-widgets a:hover,body.poetheme-has-color-settings .poetheme-footer-widgets a:focus{color:var(--poetheme-footer-widget-link-color) !important;}';
+
+    // Footer credits bar follows the footer palette (background, text and links),
+    // so it never stays white in dark mode.
+    $styles .= 'body.poetheme-has-color-settings .poetheme-footer-credits{background-color:var(--poetheme-footer-widget-background) !important;color:var(--poetheme-footer-widget-text-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-footer-credits .poetheme-footer-credits__content,body.poetheme-has-color-settings .poetheme-footer-credits p,body.poetheme-has-color-settings .poetheme-footer-credits span{color:var(--poetheme-footer-widget-text-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-footer-credits a{color:var(--poetheme-footer-widget-link-color) !important;}';
 
     if ( $styles ) {
         $styles = poetheme_sanitize_inline_css( $styles );

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.27.0
+Version: 1.28.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme

--- a/template-parts/header/style-1.php
+++ b/template-parts/header/style-1.php
@@ -121,7 +121,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-gray-200">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-4' ) ) ); ?>">
             <div class="flex items-center justify-between gap-6">
                 <div class="flex w-full items-center justify-between gap-4 md:w-auto">
@@ -165,7 +165,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"
@@ -197,7 +197,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
                 </nav>
 
                 <?php if ( $has_top_menu ) : ?>
-                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="border-t border-gray-200 pt-6">
+                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="pt-6">
                         <?php
                         poetheme_render_navigation_menu(
                             'top-info',

--- a/template-parts/header/style-2.php
+++ b/template-parts/header/style-2.php
@@ -136,7 +136,7 @@ $mobile_right_items = $right_location ? poetheme_get_navigation_menu_items( $rig
         </div>
     <?php endif; ?>
 
-    <div class="poetheme-header__main border-b border-blue-100">
+    <div class="poetheme-header__main">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
             <div class="poetheme-header__split flex items-center justify-between gap-4 md:gap-6">
                 <div class="poetheme-header__split-menu poetheme-header__split-menu--left hidden md:flex items-center justify-start">
@@ -202,7 +202,7 @@ $mobile_right_items = $right_location ? poetheme_get_navigation_menu_items( $rig
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"
@@ -229,7 +229,7 @@ $mobile_right_items = $right_location ? poetheme_get_navigation_menu_items( $rig
                 </nav>
 
                 <?php if ( $has_top_menu ) : ?>
-                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="border-t border-gray-200 pt-6">
+                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="pt-6">
                         <?php
                         poetheme_render_navigation_menu(
                             'top-info',

--- a/template-parts/header/style-3.php
+++ b/template-parts/header/style-3.php
@@ -88,7 +88,7 @@ $search_url      = get_search_link();
     x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
 >
     <?php if ( $show_top_bar && ( $has_top_items || $has_social || $has_top_menu ) ) : ?>
-        <div class="poetheme-top-bar bg-gray-50 text-xs text-gray-600 border-b border-gray-200">
+        <div class="poetheme-top-bar bg-gray-50 text-xs text-gray-600">
             <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-2', 'flex', 'flex-col', 'gap-3', 'md:flex-row', 'md:items-center', 'md:justify-between' ) ) ); ?>">
                 <?php if ( $has_top_items ) : ?>
                     <?php
@@ -140,7 +140,7 @@ $search_url      = get_search_link();
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-gray-200">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
             <div class="md:grid md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-6 flex items-center justify-between gap-4">
                 <div class="hidden md:flex items-center justify-start">
@@ -224,7 +224,7 @@ $search_url      = get_search_link();
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"
@@ -269,7 +269,7 @@ $search_url      = get_search_link();
                 </nav>
 
                 <?php if ( $has_top_menu ) : ?>
-                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="border-t border-gray-200 pt-6">
+                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="pt-6">
                         <?php
                         poetheme_render_navigation_menu(
                             'top-info',

--- a/template-parts/header/style-4.php
+++ b/template-parts/header/style-4.php
@@ -132,7 +132,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-gray-200">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
             <div class="flex items-center justify-between gap-4">
                 <div class="flex items-center gap-4">
@@ -169,7 +169,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
         </div>
     </div>
 
-    <div class="poetheme-nav-desktop border-b border-gray-200 hidden md:block">
+    <div class="poetheme-nav-desktop hidden md:block">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-3' ) ) ); ?>">
             <nav class="nav-primary flex items-center justify-between" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
@@ -203,7 +203,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"
@@ -220,7 +220,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
             </div>
 
             <div class="flex-1 min-h-0 overflow-y-auto px-4 py-6 space-y-6">
-                <div class="border-b border-gray-200 pb-6">
+                <div class="pb-6">
                     <?php get_search_form(); ?>
                 </div>
 
@@ -239,7 +239,7 @@ if ( function_exists( 'yith_wcwl_object_id' ) ) {
                 </nav>
 
                 <?php if ( $account_url || $wishlist_url || $cart_url ) : ?>
-                    <div class="flex items-center gap-4 border-t border-gray-200 pt-6 text-gray-700">
+                    <div class="flex items-center gap-4 pt-6 text-gray-700">
                         <?php if ( $account_url ) : ?>
                             <a class="hover:text-blue-600 transition" href="<?php echo esc_url( $account_url ); ?>" aria-label="<?php esc_attr_e( 'Account', 'poetheme' ); ?>">
                                 <i data-lucide="user" class="w-5 h-5"></i>

--- a/template-parts/header/style-5.php
+++ b/template-parts/header/style-5.php
@@ -121,7 +121,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-gray-200">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-4' ) ) ); ?>">
             <div class="flex items-center justify-between gap-6">
                 <div class="flex w-full items-center justify-between gap-4 md:w-auto">
@@ -165,7 +165,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"
@@ -197,7 +197,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
                 </nav>
 
                 <?php if ( $has_top_menu ) : ?>
-                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="border-t border-gray-200 pt-6">
+                    <nav aria-label="<?php esc_attr_e( 'Informazioni rapide', 'poetheme' ); ?>" class="pt-6">
                         <?php
                         poetheme_render_navigation_menu(
                             'top-info',

--- a/template-parts/header/style-6.php
+++ b/template-parts/header/style-6.php
@@ -122,7 +122,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-rose-100">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
             <div class="flex items-center justify-center">
                 <div class="flex w-full items-center justify-between md:w-auto md:justify-center">
@@ -136,7 +136,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     </div>
 
-    <div class="poetheme-nav-desktop border-b border-rose-100 hidden md:block">
+    <div class="poetheme-nav-desktop hidden md:block">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-3' ) ) ); ?>">
             <nav class="nav-primary flex items-center justify-center" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
@@ -170,7 +170,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"

--- a/template-parts/header/style-7.php
+++ b/template-parts/header/style-7.php
@@ -121,7 +121,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-gray-100">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
             <div class="flex items-center justify-start">
                 <div class="flex w-full items-center justify-between md:w-auto">
@@ -135,7 +135,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     </div>
 
-    <div class="poetheme-nav-desktop border-b border-gray-100 hidden md:block">
+    <div class="poetheme-nav-desktop hidden md:block">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-3' ) ) ); ?>">
             <nav class="nav-primary flex items-center justify-start" aria-label="<?php esc_attr_e( 'Primary navigation', 'poetheme' ); ?>">
                 <?php
@@ -169,7 +169,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"

--- a/template-parts/header/style-8.php
+++ b/template-parts/header/style-8.php
@@ -121,7 +121,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         </div>
     <?php endif; ?>
 
-    <div class="border-b border-indigo-100">
+    <div class="">
         <div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-4' ) ) ); ?>">
             <div class="flex items-center justify-between gap-6">
                 <div class="flex w-full items-center justify-between gap-4 md:w-auto">
@@ -165,7 +165,7 @@ $has_top_menu = has_nav_menu( 'top-info' );
         <div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
 
         <div
-            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col bg-white shadow-xl"
+            class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel bg-white shadow-xl"
             x-transition:enter="transition ease-in-out duration-300"
             x-transition:enter-start="translate-x-full"
             x-transition:enter-end="translate-x-0"


### PR DESCRIPTION
## Sommario
Footer e menu mobile ora seguono la palette; rimossi i bordi hardcoded dalle testate. Bump a 1.28.0.

> Nota: successiva al merge della #88.

## 🦶 Footer gestito dalla palette
- Rimosse le classi hardcoded dal template footer: `bg-white`, `bg-gray-100`, `border-t`, `border-gray-200`.
- La **barra dei crediti** ora segue lo **sfondo / testo / link** del footer della palette (regole in `head-output`): niente più fondo **bianco in modalità scura**.
- I widget del footer prendono lo sfondo dalla palette (come già avveniva), senza la classe `bg-gray-100` che confondeva.

## 🧱 Bordi testate rimossi
Eliminati i bordi hardcoded `border-t` / `border-b` (e le relative classi colore `border-gray-200`, `border-blue-100`, ecc.) da **tutte le testate (style 1–9)**, perché non gestiti dalla palette — come richiesto. Operato solo dentro gli attributi `class` per sicurezza.

## 📱 Menu mobile (smartphone) gestito dalla palette
Il pannello a scomparsa è ora una **superficie di contenuto** coerente con la palette:
- pannello: `--poetheme-content-background-color`;
- titolo / pulsante chiudi: colore testo/forte del contenuto;
- voci di menu: colore testo del contenuto, **link attivi/hover** col colore link.

Così il menu mobile **resta sempre leggibile**, anche quando i colori del menu in testata sono chiari (testata scura) — prima rischiavano testo chiaro su pannello bianco. La classe `.poetheme-mobile-panel` è stata aggiunta ai pannelli di tutte le testate; il CTA nel menu mantiene i suoi colori (escluso via `:not(.poetheme-cta-button)`).

## Verifica
- `php -l` verde (footer, head-output, style 1–9); nessun `border-t/border-b` residuo nelle testate; nessun `bg-white/border` hardcoded nel footer.
- **Test**: palette scura → footer crediti scuro (non bianco); apri il menu mobile → pannello e testo seguono la palette e restano leggibili; le testate non mostrano più i bordi grigi hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ)_