### PR TITLE
Harmonize heading colors with the brand; bring read-more/post cards under the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.29.0
+- **Colori dei titoli armonizzati:** l'algoritmo delle palette assegna ora agli H (H1–H6, titoli
+  pagina/articolo/categoria, intestazioni footer) un colore **coordinato col brand** (non più solo
+  nero/bianco), mantenendo un buon contrasto. Una migrazione rigenera le palette esistenti dai loro
+  semi (preservando le personalizzazioni) così il nuovo colore si applica anche ai preset salvati.
+- **Stili obsoleti rimossi/portati sotto palette:** i pulsanti **“Leggi di più”** (`.poetheme-read-more`)
+  usavano un blu fisso e le **card degli articoli** (`.poetheme-post-item`) uno sfondo bianco fisso,
+  ignorando la palette. Ora seguono i colori CTA/contenuto della palette.
+
 ## 1.28.0
 - **Footer gestito dalla palette:** rimosse le classi hardcoded (`bg-white`, `bg-gray-100`,
   `border-t`) dal footer. La barra dei crediti ora segue lo sfondo, il testo e i link del footer

--- a/assets/js/style-studio.js
+++ b/assets/js/style-studio.js
@@ -155,6 +155,9 @@
 
         var onDark = '#ffffff';
         var link = dark ? hsl(h, s, 70) : primary;
+        // Headings use a harmonized, brand-tinted color (not just near-black/white)
+        // while keeping strong contrast on the content surface.
+        var headingColor = dark ? hsl(h, clamp(s, 28, 62), 84) : hsl(h, clamp(s, 32, 72), 26);
 
         var colors = {
             page_background_color: page,
@@ -173,19 +176,19 @@
             top_bar_text_color: onDark,
             top_bar_link_color: onDark,
             top_bar_icon_color: onDark,
-            page_title_color: textStrong,
-            post_title_color: textStrong,
-            category_title_color: textStrong,
+            page_title_color: headingColor,
+            post_title_color: headingColor,
+            category_title_color: headingColor,
             footer_widget_background_color: footerBg,
             footer_widget_text_color: textMuted,
             footer_widget_link_color: link
         };
 
         ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach(function (tag) {
-            colors['heading_' + tag + '_color'] = textStrong;
+            colors['heading_' + tag + '_color'] = headingColor;
         });
         ['h2', 'h3', 'h4', 'h5'].forEach(function (tag) {
-            colors['footer_widget_heading_' + tag + '_color'] = textStrong;
+            colors['footer_widget_heading_' + tag + '_color'] = headingColor;
         });
 
         return {

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.28.0' );
+define( 'POETHEME_VERSION', '1.29.0' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/style-studio.php
+++ b/inc/admin/options/style-studio.php
@@ -546,6 +546,11 @@ function poetheme_studio_generate_from_seeds( $seeds ) {
 
     $on_dark = '#ffffff';
 
+    // Headings use a harmonized, brand-tinted color (not just near-black/white).
+    $heading_color = $dark
+        ? poetheme_studio_hsl_to_hex( $h, poetheme_studio_clamp( $s, 28, 62 ), 84 )
+        : poetheme_studio_hsl_to_hex( $h, poetheme_studio_clamp( $s, 32, 72 ), 26 );
+
     $colors = array(
         'page_background_color'         => $page,
         'content_background_color'      => $surface,
@@ -563,19 +568,19 @@ function poetheme_studio_generate_from_seeds( $seeds ) {
         'top_bar_text_color'            => $on_dark,
         'top_bar_link_color'            => $on_dark,
         'top_bar_icon_color'            => $on_dark,
-        'page_title_color'              => $text_strong,
-        'post_title_color'              => $text_strong,
-        'category_title_color'          => $text_strong,
+        'page_title_color'              => $heading_color,
+        'post_title_color'              => $heading_color,
+        'category_title_color'          => $heading_color,
         'footer_widget_background_color'=> $footer_bg,
         'footer_widget_text_color'      => $text_muted,
         'footer_widget_link_color'      => $link,
     );
 
     foreach ( array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ) as $tag ) {
-        $colors[ 'heading_' . $tag . '_color' ] = $text_strong;
+        $colors[ 'heading_' . $tag . '_color' ] = $heading_color;
     }
     foreach ( array( 'h2', 'h3', 'h4', 'h5' ) as $tag ) {
-        $colors[ 'footer_widget_heading_' . $tag . '_color' ] = $text_strong;
+        $colors[ 'footer_widget_heading_' . $tag . '_color' ] = $heading_color;
     }
 
     // Typography + density.
@@ -902,6 +907,50 @@ function poetheme_studio_migrate_palette_layout() {
     update_option( 'poetheme_palette_layout_migrated', 1 );
 }
 add_action( 'admin_init', 'poetheme_studio_migrate_palette_layout' );
+
+/**
+ * Regenerate stored palettes from their seeds when the generator algorithm
+ * changes, so existing palettes (including seeded presets) pick up improvements
+ * such as harmonized heading colors. User overrides are preserved (re-applied on
+ * top of the freshly generated tokens). Gated by a version bump.
+ */
+function poetheme_studio_regenerate_palettes() {
+    $version = 2; // Bump when generated tokens change and palettes should refresh.
+
+    if ( (int) get_option( 'poetheme_palette_gen_version', 0 ) >= $version ) {
+        return;
+    }
+
+    $palettes = poetheme_get_style_palettes();
+    $changed  = false;
+
+    foreach ( $palettes as $id => $palette ) {
+        if ( empty( $palette['seeds'] ) ) {
+            continue;
+        }
+
+        $rebuilt = poetheme_studio_build_palette(
+            isset( $palette['name'] ) ? $palette['name'] : '',
+            $palette['seeds'],
+            isset( $palette['origin'] ) ? $palette['origin'] : 'studio',
+            isset( $palette['overrides'] ) ? $palette['overrides'] : array()
+        );
+
+        if ( isset( $palette['created'] ) ) {
+            $rebuilt['created'] = $palette['created'];
+        }
+
+        $palettes[ $id ] = $rebuilt;
+        $changed         = true;
+    }
+
+    if ( $changed ) {
+        update_option( 'poetheme_style_palettes', $palettes );
+    }
+
+    update_option( 'poetheme_palette_gen_version', $version );
+}
+add_action( 'admin_init', 'poetheme_studio_regenerate_palettes' );
 
 
 /**

--- a/inc/head-output.php
+++ b/inc/head-output.php
@@ -204,6 +204,12 @@ function poetheme_get_design_settings_css() {
     $styles .= 'body.poetheme-has-color-settings .poetheme-cta-button{background-color:var(--poetheme-cta-background-color) !important;color:var(--poetheme-cta-text-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-cta-button:hover,body.poetheme-has-color-settings .poetheme-cta-button:focus{background-color:var(--poetheme-cta-background-color) !important;color:var(--poetheme-cta-text-color) !important;}';
 
+    // "Read more" buttons and post cards follow the palette (legacy hardcoded
+    // colors in style.css used a fixed blue / white that ignored the palette).
+    $styles .= 'body.poetheme-has-color-settings .poetheme-read-more{background-color:var(--poetheme-cta-background-color) !important;color:var(--poetheme-cta-text-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-read-more--outline{background-color:transparent !important;color:var(--poetheme-content-link-color) !important;border-color:var(--poetheme-content-link-color) !important;}';
+    $styles .= 'body.poetheme-has-color-settings .poetheme-post-item{background-color:var(--poetheme-content-background-color) !important;}';
+
     $styles .= 'body.poetheme-has-color-settings .poetheme-top-bar{background-color:var(--poetheme-top-bar-background) !important;color:var(--poetheme-top-bar-text-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-top-bar,body.poetheme-has-color-settings .poetheme-top-bar p,body.poetheme-has-color-settings .poetheme-top-bar span{color:var(--poetheme-top-bar-text-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings .poetheme-top-bar a{color:var(--poetheme-top-bar-link-color) !important;}';

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.28.0
+Version: 1.29.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Sommario
Armonizzazione dei colori dei titoli e rimozione di stili obsoleti che ignoravano la palette. Bump a 1.29.0.

> Nota: successiva al merge della #89.

## 🎨 Colori dei titoli armonizzati col brand
Prima l'algoritmo assegnava agli H un colore quasi nero/bianco (neutro). Ora i titoli (H1–H6, titolo pagina/articolo/categoria, intestazioni footer) usano un colore **coordinato col brand**, mantenendo un buon contrasto:
- brand blu `#2563eb` → titoli `#133072`
- brand verde `#16a34a` → titoli `#137236`
- brand indaco in **dark** → titoli `#bdbeef`

Il **testo del corpo** resta neutro (leggibilità); solo i titoli sono colorati. Logica speculare in JS (anteprima) e PHP (generatore).

**Migrazione:** rigenera le palette esistenti dai loro **semi** (preservando gli override dell'utente), così anche i preset già salvati adottano i nuovi colori dei titoli. Gated da una versione del generatore (`poetheme_palette_gen_version`).

## 🧹 Stili obsoleti portati sotto la palette
- **`.poetheme-read-more`** ("Leggi di più"): usava un blu fisso (`--poetheme-focus-color`) e bianco → ora usa i colori **CTA** della palette; la variante `--outline` usa il colore **link**.
- **`.poetheme-post-item`** (card articoli): sfondo bianco fisso → ora usa lo **sfondo contenuto** della palette (niente più card bianche in dark mode).

Regole aggiunte in `head-output` (sotto `body.poetheme-has-color-settings`, con `!important` per battere le regole legacy in `style.css`).

## Verifica
- `php -l` verde; `node --check` JS ok; test PHP conferma colori titoli armonizzati e non grayscale.
- **Test**: applica/crea una palette → i titoli del contenuto sono colorati col brand (non neri); i pulsanti "Leggi di più" e le card articoli seguono la palette anche in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb66QkgkKbw2BoHjieogvJ)_