### PR TITLE
feat(header): testata dedicata &quot;Palladio · Sambiasi&quot; — Style 10 (v1.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.34.0
+- **Nuova testata Style 10 — "Palladio · Sambiasi":** header editoriale dedicato al plugin Palladio con nome/logo del progetto, navigazione, switcher lingua del plugin (shortcode `[palladio_lang_switcher]`) e CTA "Richiedi una visita". Responsive con drawer mobile; segue la palette e i font del tema (variabili `--poetheme-*`) con fallback caldi. Selezionabile da **Impostazioni testata**.
+
 ## 1.33.0
 - **Nuovo preset "Sambiasi":** aggiunta una palette Style Studio dalla direzione visiva editoriale (carta calda `#f7f2e7`, bordeaux `#6e2b2b`, oro `#a4906a`), con titoli serif, CTA bordeaux e piè di pagina scuro. Pensata per armonizzare header e footer del tema con le schede immobiliari del plugin Palladio.
 - **Preset con override cromatici:** il seeding dei preset può ora includere override dei singoli token (non solo i semi), così un preset può fissare esattamente la propria palette. Le installazioni già inizializzate ricevono i nuovi preset tramite un backfill idempotente eseguito una sola volta (rispetta i preset eventualmente eliminati dall'utente).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tema WordPress moderno sviluppato da Cosè Murciano con pieno supporto per l'edi
 ## Changelog
 Lo storico completo e versionato è in [`CHANGELOG.md`](CHANGELOG.md). Di seguito i punti salienti delle release recenti (la lista integrale, dalla 1.8.x alla 1.33.0, è nel changelog).
 
+- **1.34.0 — Testata "Palladio · Sambiasi":** nuovo header Style 10 dedicato al plugin Palladio (nome/logo, navigazione, switcher lingua, CTA), responsive e coordinato con la palette del tema.
 - **1.33.0 — Preset "Sambiasi":** palette editoriale (carta calda, bordeaux, oro) con titoli serif e footer scuro, coordinata con le schede immobiliari del plugin Palladio; i preset possono ora fissare override cromatici, con backfill idempotente per le installazioni esistenti.
 - **1.10.0 → 1.32.0 — Style Studio e palette cromatiche:** introduzione e progressiva maturazione del sistema di design centralizzato (vedi sezione dedicata più sotto). Generatore di palette dai semi (colore brand + regola di armonia), tipografia e densità, personalizzazione avanzata dei singoli token, auto-contrasto **WCAG AA** e gestione dei preset come palette a tutti gli effetti.
 - **1.30–1.32:** tutti i pulsanti, i meta articolo, il footer e le testate seguono i colori della palette; auto-contrasto WCAG AA su testo/link/titoli; fix Testata 2 (Split semitrasparente) e home blog senza nome sito nel contenuto.
@@ -140,6 +141,7 @@ Obiettivo: garantire la conformità a livello di tema (struttura, navigazione, f
 - Style 7 (Stack | Left): nessuna modifica (layout conforme).
 - Style 8 (Plain): nessuna modifica (layout conforme).
 - Style 9 (App Sidebar): sidebar verticale collassabile con logo in alto, menu laterale, titolo pagina e breadcrumb nell’area contenuto, profilo sito/autore in basso.
+- Style 10 (Palladio · Sambiasi): testata editoriale dedicata al plugin Palladio — nome/logo del progetto, navigazione, switcher lingua del plugin e CTA "Richiedi una visita"; responsive con drawer mobile, palette e font del tema.
 
 ## Asset Policy (M5)
 - Preferire asset locali e versionati.

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.33.0' );
+define( 'POETHEME_VERSION', '1.34.0' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/header.php
+++ b/inc/admin/options/header.php
@@ -91,6 +91,11 @@ function poetheme_get_header_layout_choices() {
             'image'       => '',
             'preview'     => 'app-sidebar',
         ),
+        'style-10' => array(
+            'label'       => __( 'Palladio · Sambiasi', 'poetheme' ),
+            'description' => __( 'Testata editoriale dedicata al plugin Palladio: nome/logo del progetto, navigazione, switcher lingua e CTA “Richiedi una visita”. Segue la palette e i font del tema, responsive con drawer mobile.', 'poetheme' ),
+            'image'       => '',
+        ),
     );
 }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.33.0
+Version: 1.34.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -2016,5 +2016,106 @@ body.poetheme-mobile-drawer-open {
 @media (prefers-reduced-motion: reduce) {
   .pagination .page-numbers {
     transition: none;
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Header Style 10 — Palladio · Sambiasi
+ * Testata editoriale dedicata al plugin; segue la palette (variabili --poetheme-*)
+ * con fallback caldi. Layout responsive con drawer mobile.
+ * -------------------------------------------------------------------------- */
+.poetheme-header--style-10 {
+  background: var(--poetheme-header-background-color, #f7f2e7);
+  border-bottom: 1px solid color-mix(in srgb, var(--poetheme-content-text-color, #2e2a23) 14%, transparent);
+}
+
+.poetheme-header--style-10__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.poetheme-header--style-10__brand {
+  font-family: var(--poetheme-heading-font-family, 'Playfair Display', Georgia, serif);
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  letter-spacing: 0.01em;
+  line-height: 1;
+}
+
+.poetheme-header--style-10__brand a,
+.poetheme-header--style-10__brand .poetheme-logo-text {
+  color: var(--poetheme-page-title-color, #2e2a23);
+  text-decoration: none;
+}
+
+.poetheme-header--style-10__nav {
+  display: none;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.poetheme-header--style-10__menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.poetheme-header--style-10__menu a {
+  color: var(--poetheme-menu-link-color, #2e2a23);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  transition: color 0.15s ease;
+}
+
+.poetheme-header--style-10__menu a:hover {
+  color: var(--poetheme-menu-active-link-color, #6e2b2b);
+}
+
+.poetheme-header--style-10__cta {
+  display: inline-block;
+  padding: 0.6rem 1.25rem;
+  border-radius: 2px;
+  background: var(--poetheme-cta-background-color, #6e2b2b);
+  color: var(--poetheme-cta-text-color, #f7f2e7);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  white-space: nowrap;
+  border: 1px solid var(--poetheme-cta-background-color, #6e2b2b);
+  transition: opacity 0.15s ease;
+}
+
+.poetheme-header--style-10__cta:hover {
+  opacity: 0.9;
+}
+
+.poetheme-header--style-10__toggle {
+  color: var(--poetheme-menu-link-color, #2e2a23);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.poetheme-header--style-10__panel {
+  background: var(--poetheme-content-background-color, #fffdf8);
+  color: var(--poetheme-content-text-color, #2e2a23);
+}
+
+.poetheme-header--style-10__cta--mobile {
+  display: inline-flex;
+  width: 100%;
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .poetheme-header--style-10__nav {
+    display: flex;
+  }
+  .poetheme-header--style-10__toggle {
+    display: none;
   }
 }

--- a/template-parts/header/style-10.php
+++ b/template-parts/header/style-10.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Header layout: Style 10 (Palladio · Sambiasi).
+ *
+ * Testata dedicata al plugin Palladio, coerente con la direzione visiva
+ * editoriale: nome/logo del progetto a sinistra, navigazione, switcher lingua
+ * del plugin e CTA "Richiedi una visita" a destra. Responsive con drawer
+ * mobile. Lo stile vive in style.css (scoped a --style-10) e segue la palette.
+ *
+ * @package PoeTheme
+ */
+
+if ( ! isset( $args ) || ! is_array( $args ) ) {
+	$args = array();
+}
+
+$defaults = array(
+	'cta_text' => '',
+	'cta_url'  => '',
+	'show_cta' => true,
+);
+$context  = wp_parse_args( $args, $defaults );
+
+$cta_text = trim( (string) $context['cta_text'] );
+$cta_url  = $context['cta_url'];
+$show_cta = ! empty( $context['show_cta'] ) && '' !== $cta_text;
+
+$has_menu = has_nav_menu( 'primary' );
+
+// Switcher lingua fornito dal plugin Palladio (se attivo).
+$lang_switcher = shortcode_exists( 'palladio_lang_switcher' ) ? do_shortcode( '[palladio_lang_switcher]' ) : '';
+
+$mobile_items = $has_menu ? poetheme_get_navigation_menu_items( 'primary', 'mobile' ) : '';
+?>
+<header
+	class="poetheme-site-header poetheme-site-header--style-10 poetheme-header poetheme-header--style-10"
+	role="banner"
+	x-data="{ mobileOpen: false }"
+	x-effect="document.documentElement.classList.toggle('overflow-hidden', mobileOpen); document.body.classList.toggle('overflow-hidden', mobileOpen);"
+>
+	<div class="poetheme-header__main">
+		<div class="<?php echo esc_attr( poetheme_get_layout_container_classes( array( 'py-5' ) ) ); ?>">
+			<div class="poetheme-header--style-10__bar">
+
+				<div class="poetheme-header--style-10__brand">
+					<?php poetheme_the_logo(); ?>
+				</div>
+
+				<button type="button"
+					class="poetheme-header__toggle poetheme-nav-toggle poetheme-header--style-10__toggle md:hidden"
+					@click="mobileOpen = ! mobileOpen"
+					:aria-expanded="mobileOpen.toString()"
+					aria-controls="poetheme-mobile-menu"
+					aria-haspopup="true">
+					<span class="sr-only"><?php esc_html_e( 'Apri il menù principale', 'poetheme' ); ?></span>
+					<i data-lucide="menu" class="w-6 h-6"></i>
+				</button>
+
+				<div class="poetheme-header--style-10__nav">
+					<?php if ( $has_menu ) : ?>
+						<nav class="nav-primary poetheme-nav-desktop" aria-label="<?php esc_attr_e( 'Navigazione principale', 'poetheme' ); ?>">
+							<?php
+							poetheme_render_navigation_menu(
+								'primary',
+								'desktop',
+								array(
+									'menu_class'  => 'poetheme-header--style-10__menu flex items-center gap-7 text-sm',
+									'fallback_cb' => false,
+								)
+							);
+							?>
+						</nav>
+					<?php endif; ?>
+
+					<?php if ( '' !== $lang_switcher ) : ?>
+						<div class="poetheme-header--style-10__lang"><?php echo $lang_switcher; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+					<?php endif; ?>
+
+					<?php if ( $show_cta ) : ?>
+						<a class="poetheme-cta-button poetheme-header--style-10__cta" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta_text ); ?></a>
+					<?php endif; ?>
+				</div>
+
+			</div>
+		</div>
+	</div>
+
+	<div
+		id="poetheme-mobile-menu"
+		x-show="mobileOpen"
+		x-cloak
+		class="poetheme-nav-mobile fixed inset-0 z-50 md:hidden"
+		@keydown.escape.window="mobileOpen = false"
+		x-transition:enter="transition-opacity ease-linear duration-200"
+		x-transition:enter-start="opacity-0"
+		x-transition:enter-end="opacity-100"
+		x-transition:leave="transition-opacity ease-linear duration-200"
+		x-transition:leave-start="opacity-100"
+		x-transition:leave-end="opacity-0"
+	>
+		<div class="absolute inset-0 bg-gray-900/50" @click="mobileOpen = false" aria-hidden="true"></div>
+
+		<div
+			class="relative ml-auto flex h-full w-11/12 max-w-xs flex-col poetheme-mobile-panel poetheme-header--style-10__panel"
+			x-transition:enter="transition ease-in-out duration-300"
+			x-transition:enter-start="translate-x-full"
+			x-transition:enter-end="translate-x-0"
+			x-transition:leave="transition ease-in-out duration-300"
+			x-transition:leave-start="translate-x-0"
+			x-transition:leave-end="translate-x-full"
+		>
+			<div class="poetheme-mobile-panel__header">
+				<span class="poetheme-mobile-panel__title"><?php esc_html_e( 'Menu', 'poetheme' ); ?></span>
+				<button type="button" @click="mobileOpen = false">
+					<span class="sr-only"><?php esc_html_e( 'Chiudi il menù principale', 'poetheme' ); ?></span>
+					<i data-lucide="x" class="w-6 h-6"></i>
+				</button>
+			</div>
+
+			<div class="flex-1 min-h-0 overflow-y-auto px-4 py-6 space-y-6">
+				<?php if ( $has_menu ) : ?>
+					<nav aria-label="<?php esc_attr_e( 'Navigazione principale', 'poetheme' ); ?>">
+						<ul class="poetheme-nav poetheme-nav--mobile poetheme-nav--location-primary flex flex-col gap-4 text-base font-medium" data-poetheme-nav="1" data-variant="mobile" data-location="primary">
+							<?php echo $mobile_items; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						</ul>
+					</nav>
+				<?php endif; ?>
+
+				<?php if ( '' !== $lang_switcher ) : ?>
+					<div class="poetheme-header--style-10__lang poetheme-header--style-10__lang--mobile"><?php echo $lang_switcher; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+				<?php endif; ?>
+
+				<?php if ( $show_cta ) : ?>
+					<a class="poetheme-cta-button poetheme-header--style-10__cta poetheme-header--style-10__cta--mobile" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta_text ); ?></a>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+</header>


### PR DESCRIPTION
## Contesto

Su richiesta: **creare in Impostazioni testata un layout dedicato al plugin che rispetti il layout grafico e funzionale del file HTML** (responsive). Terza tappa del batch.

## Cosa introduce

- **Nuovo header Style 10 — "Palladio · Sambiasi"** (`template-parts/header/style-10.php`) che replica l'header del riferimento: **nome/logo del progetto** a sinistra; a destra **navigazione**, **switcher lingua del plugin** (`[palladio_lang_switcher]`, reso solo se Palladio è attivo) e **CTA "Richiedi una visita"**.
- **Responsive**: drawer mobile con overlay ed ESC, riusando il pattern Alpine del tema; breakpoint desktop/mobile a 768px.
- Registrato come `style-10` in `poetheme_get_header_layout_choices()` → **selezionabile da Impostazioni testata**.
- **CSS autosufficiente** in `style.css` (scoped a `.poetheme-header--style-10`) che segue le **variabili di palette** (`--poetheme-*`) con fallback caldi; brand serif; nessuna dipendenza da utility Tailwind non presenti nel build.
- Bump a **1.34.0**, CHANGELOG e README aggiornati (audit testate).

## Verifica

- Lint `php -l` OK su `style-10.php` e `header.php`.
- Additivo: non tocca gli altri layout; la CTA e il menu usano gli helper esistenti del tema.

## Note

Quarta e ultima tappa del batch: far usare all'Agent **OpenAI Storage / File Search + i media del sito** per popolare automaticamente i campi strutturati delle pagine (PR sul plugin Palladio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_