### PR TITLE
fix(header): Style 10 salta subheader e title ownership (v1.34.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.34.1
+- **Allineamento testata Style 10 (Palladio):** lo Style 10 non stampa più il subheader del tema (titolo pagina + breadcrumb) e non “possiede” il titolo, evitando la duplicazione sopra l'hero editoriale delle schede del plugin Palladio (che rendono il proprio titolo). Coerente con lo Style 9 – App Sidebar.
+
 ## 1.34.0
 - **Nuova testata Style 10 — "Palladio · Sambiasi":** header editoriale dedicato al plugin Palladio con nome/logo del progetto, navigazione, switcher lingua del plugin (shortcode `[palladio_lang_switcher]`) e CTA "Richiedi una visita". Responsive con drawer mobile; segue la palette e i font del tema (variabili `--poetheme-*`) con fallback caldi. Selezionabile da **Impostazioni testata**.
 

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.34.0' );
+define( 'POETHEME_VERSION', '1.34.1' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/header.php
+++ b/header.php
@@ -31,6 +31,6 @@ get_template_part( $template_slug, null, $header_context );
 ?>
 
 <main id="primary-content" class="<?php echo esc_attr( poetheme_get_main_classes() ); ?>" tabindex="-1">
-    <?php if ( 'style-9' !== $layout ) : ?>
+    <?php if ( ! in_array( $layout, array( 'style-9', 'style-10' ), true ) ) : ?>
         <?php poetheme_render_subheader(); ?>
     <?php endif; ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -110,6 +110,13 @@ function poetheme_is_app_sidebar_layout() {
  * @return bool
  */
 function poetheme_header_owns_page_title() {
+    // Style 10 (Palladio) non stampa il subheader: non possiede il titolo, che
+    // è reso dai template del plugin (hero editoriale).
+    $header_options = function_exists( 'poetheme_get_header_options' ) ? poetheme_get_header_options() : array();
+    if ( isset( $header_options['layout'] ) && 'style-10' === $header_options['layout'] ) {
+        return false;
+    }
+
     return poetheme_is_app_sidebar_layout() || poetheme_subheader_is_enabled();
 }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.34.0
+Version: 1.34.1
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Allineamento impostazioni tema (verifica richiesta)

Lo **Style 10 (Palladio)** è usato sulle pagine editoriali del plugin, che renderizzano **il proprio titolo nell'hero**. Il tema però stampava comunque il **subheader** (titolo pagina + breadcrumb) sopra di esse → **titolo duplicato**.

### Correzioni
- `header.php`: lo Style 10 **non stampa più il subheader** (come lo Style 9).
- `poetheme_header_owns_page_title()` restituisce **false** per lo Style 10, così il tema non “possiede” il titolo (che è del plugin).

### Audit impostazioni
- **Preset "Sambiasi"**: verificate le **21 chiavi colore** degli override → tutte valide (presenti nel whitelist di `colors.php`), il preset si applica correttamente.
- Registrazione Style 10 in *Impostazioni testata*, versione (1.34.1), README/CHANGELOG: coerenti.

## Verifica
- Lint `php -l` OK su `header.php` e `inc/template-tags.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_