### PR TITLE
feat(header): Style 10 barra scura Sambiasi; pagine Palladio full-bleed (v1.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.35.0
+- **Style 10 — barra editoriale scura (riferimento Sambiasi):** la testata Palladio è ora la barra scura del riferimento visivo: brand in serif crema, navigazione maiuscoletta crema con voce attiva/hover in oro (sottolineatura fine), switcher lingua del plugin stilizzato sui codici brevi (`.palladio-lang`, corrente in oro) e CTA testuale oro "Richiedi una visita" (non più bottone pieno) con default automatico verso il modulo contatti (`#palladio-contact`). Drawer mobile scuro coerente.
+- **Pagine Palladio full-bleed:** su schede e archivi del plugin (edificio, unità, scenari, storia e homepage-edificio) il `main` non impone più container, max-width né padding (`poetheme-palladio-main`): spariscono le fasce laterali e i disallineamenti delle sezioni a piena larghezza. Lo sfondo del body segue la carta editoriale (`#f7f2e7`) con `overflow-x: hidden`.
+
 ## 1.34.1
 - **Allineamento testata Style 10 (Palladio):** lo Style 10 non stampa più il subheader del tema (titolo pagina + breadcrumb) e non “possiede” il titolo, evitando la duplicazione sopra l'hero editoriale delle schede del plugin Palladio (che rendono il proprio titolo). Coerente con lo Style 9 – App Sidebar.
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -437,11 +437,37 @@ function poetheme_get_layout_container_classes( $additional = array(), $include_
 }
 
 /**
- * Retrieve main element classes accounting for page settings.
+ * Indica se la richiesta corrente è una pagina del plugin Palladio.
+ *
+ * @return bool
+ */
+function poetheme_is_palladio_request() {
+    $types = array( 'pll_edificio', 'pll_unita', 'pll_scenario', 'pll_storia' );
+
+    if ( is_singular( $types ) || is_post_type_archive( $types ) ) {
+        return true;
+    }
+
+    // Homepage servita dalla landing di un edificio Palladio.
+    if ( is_front_page() && (int) get_option( 'palladio_home_building', 0 ) > 0 ) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Get main element classes.
  *
  * @return string
  */
 function poetheme_get_main_classes() {
+    // Le pagine Palladio sono full-bleed: nessun container, nessun padding —
+    // il plugin gestisce larghezze e sezioni a piena larghezza da solo.
+    if ( function_exists( 'palladio' ) && poetheme_is_palladio_request() ) {
+        return 'poetheme-palladio-main';
+    }
+
     if ( poetheme_is_app_sidebar_layout() ) {
         $classes = array( 'poetheme-app-content' );
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.34.1
+Version: 1.35.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -2021,12 +2021,16 @@ body.poetheme-mobile-drawer-open {
 
 /* -----------------------------------------------------------------------------
  * Header Style 10 — Palladio · Sambiasi
- * Testata editoriale dedicata al plugin; segue la palette (variabili --poetheme-*)
- * con fallback caldi. Layout responsive con drawer mobile.
+ * Barra editoriale scura sopra il hero (come da direzione visiva): brand in
+ * serif crema, navigazione maiuscoletta crema con voce attiva oro, switcher
+ * lingua e CTA testuale oro. Palette sovrascrivibile via variabili --poetheme-*.
  * -------------------------------------------------------------------------- */
 .poetheme-header--style-10 {
-  background: var(--poetheme-header-background-color, #f7f2e7);
-  border-bottom: 1px solid color-mix(in srgb, var(--poetheme-content-text-color, #2e2a23) 14%, transparent);
+  --pt10-bg: var(--poetheme-header-background-color, #241f18);
+  --pt10-ink: #f2ead9;
+  --pt10-gold: #c2a878;
+  background: var(--pt10-bg);
+  border-bottom: 1px solid rgba(242, 234, 217, 0.12);
 }
 
 .poetheme-header--style-10__bar {
@@ -2037,16 +2041,24 @@ body.poetheme-mobile-drawer-open {
 }
 
 .poetheme-header--style-10__brand {
-  font-family: var(--poetheme-heading-font-family, 'Playfair Display', Georgia, serif);
-  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-family: var(--poetheme-heading-font-family, 'Cormorant Garamond', Georgia, serif);
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
   letter-spacing: 0.01em;
   line-height: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .poetheme-header--style-10__brand a,
 .poetheme-header--style-10__brand .poetheme-logo-text {
-  color: var(--poetheme-page-title-color, #2e2a23);
+  color: var(--pt10-ink);
   text-decoration: none;
+}
+
+.poetheme-header--style-10__brand img {
+  max-height: 3rem;
+  width: auto;
 }
 
 .poetheme-header--style-10__nav {
@@ -2062,53 +2074,99 @@ body.poetheme-mobile-drawer-open {
 }
 
 .poetheme-header--style-10__menu a {
-  color: var(--poetheme-menu-link-color, #2e2a23);
+  color: rgba(242, 234, 217, 0.82);
   text-decoration: none;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  font-size: 0.74rem;
   font-weight: 600;
-  transition: color 0.15s ease;
+  padding-bottom: 4px;
+  border-bottom: 1px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .poetheme-header--style-10__menu a:hover {
-  color: var(--poetheme-menu-active-link-color, #6e2b2b);
+  color: var(--pt10-gold);
 }
 
+.poetheme-header--style-10__menu .current-menu-item > a,
+.poetheme-header--style-10__menu .current_page_item > a,
+.poetheme-header--style-10__menu .current-menu-ancestor > a {
+  color: var(--pt10-gold);
+  border-bottom-color: var(--pt10-gold);
+}
+
+/* Switcher lingua del plugin: codici brevi in crema, attivo oro. */
+.poetheme-header--style-10__lang,
+.poetheme-header--style-10__lang a {
+  color: rgba(242, 234, 217, 0.7);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-decoration: none;
+}
+
+.poetheme-header--style-10__lang .palladio-lang {
+  color: rgba(242, 234, 217, 0.7);
+  margin-left: 0.6rem;
+}
+
+.poetheme-header--style-10__lang a.palladio-lang:hover,
+.poetheme-header--style-10__lang .palladio-lang.is-current {
+  color: var(--pt10-gold);
+}
+
+/* CTA testuale oro, come da riferimento (niente bottone pieno). */
 .poetheme-header--style-10__cta {
   display: inline-block;
-  padding: 0.6rem 1.25rem;
-  border-radius: 2px;
-  background: var(--poetheme-cta-background-color, #6e2b2b);
-  color: var(--poetheme-cta-text-color, #f7f2e7);
+  padding: 0.35rem 0;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--pt10-gold);
+  border-radius: 0;
+  color: var(--pt10-gold);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
   text-decoration: none;
   white-space: nowrap;
-  border: 1px solid var(--poetheme-cta-background-color, #6e2b2b);
-  transition: opacity 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .poetheme-header--style-10__cta:hover {
-  opacity: 0.9;
+  color: var(--pt10-ink);
+  border-bottom-color: var(--pt10-ink);
+  opacity: 1;
 }
 
 .poetheme-header--style-10__toggle {
-  color: var(--poetheme-menu-link-color, #2e2a23);
+  color: var(--pt10-ink);
   background: transparent;
   border: 0;
   cursor: pointer;
 }
 
 .poetheme-header--style-10__panel {
-  background: var(--poetheme-content-background-color, #fffdf8);
-  color: var(--poetheme-content-text-color, #2e2a23);
+  background: #241f18;
+  color: var(--pt10-ink);
+}
+
+.poetheme-header--style-10__panel .poetheme-mobile-panel__title,
+.poetheme-header--style-10__panel a {
+  color: var(--pt10-ink);
+}
+
+.poetheme-header--style-10__panel .current-menu-item > a {
+  color: var(--pt10-gold);
 }
 
 .poetheme-header--style-10__cta--mobile {
   display: inline-flex;
   width: 100%;
   justify-content: center;
+  border: 1px solid var(--pt10-gold);
+  padding: 0.6rem 1rem;
 }
 
 @media (min-width: 768px) {
@@ -2118,4 +2176,21 @@ body.poetheme-mobile-drawer-open {
   .poetheme-header--style-10__toggle {
     display: none;
   }
+}
+
+/* -----------------------------------------------------------------------------
+ * Pagine Palladio — allineamento tema/plugin
+ * Il contenuto è full-bleed: il main non impone container, padding né sfondo;
+ * lo sfondo del body segue la carta editoriale (niente fasce grigie laterali).
+ * -------------------------------------------------------------------------- */
+.poetheme-palladio-main {
+  width: 100%;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+}
+
+body.palladio {
+  background: #f7f2e7;
+  overflow-x: hidden;
 }

--- a/template-parts/header/style-10.php
+++ b/template-parts/header/style-10.php
@@ -23,7 +23,15 @@ $context  = wp_parse_args( $args, $defaults );
 
 $cta_text = trim( (string) $context['cta_text'] );
 $cta_url  = $context['cta_url'];
-$show_cta = ! empty( $context['show_cta'] ) && '' !== $cta_text;
+
+// Default coerente con Palladio: CTA verso il modulo contatti unico.
+if ( '' === $cta_text ) {
+	$cta_text = __( 'Richiedi una visita', 'poetheme' );
+}
+if ( empty( $cta_url ) ) {
+	$cta_url = '#palladio-contact';
+}
+$show_cta = ! empty( $context['show_cta'] );
 
 $has_menu = has_nav_menu( 'primary' );
 


### PR DESCRIPTION
## Analisi (no.png vs si.png)

Due cause del disallineamento:

1. **`<main>` è un container** (`poetheme-container px-4… pt-10 pb-10` da `poetheme_get_main_classes()`): il contenuto Palladio finiva in un box centrato con padding → fasce laterali, banda grigia del body (`bg-gray-50`) e sezioni full-bleed disallineate.
2. **Style 10 era una barra chiara** su carta, mentre il riferimento (si.png) è la **barra scura** con nav crema e accenti oro; la CTA header ereditava il testo generico delle opzioni ("Get Started").

## Style 10 — barra editoriale scura

- Sfondo **scuro caldo `#241f18`** (sovrascrivibile via `--poetheme-header-background-color`), brand in serif crema.
- Navigazione maiuscoletta crema, **voce attiva/hover in oro** con sottolineatura fine (`current-menu-item`/`ancestor`).
- **Switcher lingua** stilizzato sul markup reale del plugin (`.palladio-lang`, corrente `.is-current` in oro).
- **CTA testuale oro** "Richiedi una visita" (niente bottone pieno, come nel riferimento) con **default automatico** testo + URL `#palladio-contact` quando le opzioni testata sono vuote.
- Drawer mobile scuro coerente.

## Pagine Palladio full-bleed

- Nuovo helper `poetheme_is_palladio_request()` (schede/archivi dei CPT Palladio + homepage-edificio).
- `poetheme_get_main_classes()` su quelle pagine restituisce `poetheme-palladio-main`: **niente container, max-width né padding** — il plugin gestisce da solo larghezze e sezioni 100vw.
- `body.palladio`: sfondo carta `#f7f2e7` e `overflow-x: hidden`.

## Verifica allineamento funzionale

- Lo Style 10 già salta subheader e titolo pagina (v1.34.1) — invariato.
- Il subheader resta attivo per gli altri layout; le pagine non-Palladio non cambiano.
- Da fare lato sito: selezionare **Style 10** in Impostazioni testata (in no.png è attivo un altro layout, con "Get Started").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_