### PR TITLE
fix(fonts): rimossa la dimensione testo globale che sovrascriveva tutto (v1.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.35.1
+- **Rimossa la "Dimensione testo (rem)" globale del contenuto:** la regola generata (`body.poetheme-has-font-settings` su body, form, `main p/li/ul/ol/dd/dt` e `.entry-content`) forzava un'unica dimensione su quasi tutto il testo, schiacciando ogni scala tipografica — plugin Palladio incluso. Il campo non viene più emesso né mostrato; l'eventuale valore salvato (`body_font_size`) resta nel database ma è inerte. La dimensione base torna quella del tema/CSS.
+
 ## 1.35.0
 - **Style 10 — barra editoriale scura (riferimento Sambiasi):** la testata Palladio è ora la barra scura del riferimento visivo: brand in serif crema, navigazione maiuscoletta crema con voce attiva/hover in oro (sottolineatura fine), switcher lingua del plugin stilizzato sui codici brevi (`.palladio-lang`, corrente in oro) e CTA testuale oro "Richiedi una visita" (non più bottone pieno) con default automatico verso il modulo contatti (`#palladio-contact`). Drawer mobile scuro coerente.
 - **Pagine Palladio full-bleed:** su schede e archivi del plugin (edificio, unità, scenari, storia e homepage-edificio) il `main` non impone più container, max-width né padding (`poetheme-palladio-main`): spariscono le fasce laterali e i disallineamenti delle sezioni a piena larghezza. Lo sfondo del body segue la carta editoriale (`#f7f2e7`) con `overflow-x: hidden`.

--- a/inc/admin/options/fonts.php
+++ b/inc/admin/options/fonts.php
@@ -933,32 +933,10 @@ function poetheme_get_font_field_config() {
                 'select',
                 'textarea',
             ),
-            'size'            => array(
-                'option_key'  => 'body_font_size',
-                'label'       => __( 'Dimensione testo (rem)', 'poetheme' ),
-                'description' => __( 'Imposta la dimensione base del font per il contenuto usando i rem.', 'poetheme' ),
-                'min'         => 0.5,
-                'max'         => 3,
-                'step'        => 0.05,
-                'default'     => 1,
-                // Target the body plus the main content text and lists explicitly
-                // so paragraphs, list items and nested lists all pick up the size.
-                'selectors'   => array(
-                    'body',
-                    'button',
-                    'input',
-                    'select',
-                    'textarea',
-                    'main',
-                    'main p',
-                    'main li',
-                    'main ul',
-                    'main ol',
-                    'main dd',
-                    'main dt',
-                    '.entry-content',
-                ),
-            ),
+            // NOTA: la "Dimensione testo (rem)" globale è stata rimossa — la
+            // regola generata (body + form + main p/li + .entry-content) era
+            // troppo aggressiva e sovrascriveva ogni scala tipografica, plugin
+            // Palladio incluso. La dimensione base resta quella del tema/CSS.
         ),
         'cta_text_color' => array(
             'option_key'      => 'cta_text_font',

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.0
+Version: 1.35.1
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Problema

La regola segnalata:

```css
body.poetheme-has-font-settings, …button, …input, …select, …textarea,
…main, …main p, …main li, …main ul, …main ol, …main dd, …main dt,
….entry-content { font-size: 0.8rem; }
```

è generata dall'opzione **"Dimensione testo (rem)"** del font del contenuto (`body_font_size`). I selettori — body, controlli form e tutto il testo dentro `main` — forzavano un'unica dimensione su quasi tutto il sito, annullando ogni scala tipografica, plugin Palladio incluso.

## Fix

Rimosso il blocco `size` dal campo body nella configurazione dei font:

- la regola **non viene più generata** (il generatore itera i campi `size` della config);
- il controllo "Dimensione testo (rem)" **non compare più** nella pagina Font;
- il valore eventualmente salvato nel database (`body_font_size`) resta ma è **inerte** — nessuna migrazione necessaria (anche il seeding Style Studio continua a scriverlo senza effetto);
- la dimensione base del testo torna quella del tema/CSS.

Le dimensioni con selettori mirati (es. testo del pulsante CTA) restano funzionanti.

## Test

`php -l inc/admin/options/fonts.php` → nessun errore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_