### PR TITLE
fix(header): logo Style 10 rispetta l'altezza configurata; colori scroll actions dedicati (v1.35.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.35.2
+- **Logo Style 10 — ridimensionamento corretto:** il tetto `max-height: 3rem` della testata Palladio · Sambiasi sovrascriveva l'opzione "Altezza logo" del tema (stile inline). Ora il tetto si applica solo ai loghi senza altezza configurata (`img:not([style])`): con l'opzione impostata vince la dimensione scelta in admin.
+- **Icone scroll actions — colore non più sovrascritto:** i pulsanti flottanti (torna su, commenti, condividi) usavano il colore dei link del menu; con palette pensate per testate scure (es. Sambiasi, link chiari) le icone diventavano invisibili sui cerchi bianchi quando non attive. Ora usano una catena di variabili dedicata: `--poetheme-scroll-action-color` → colore testo contenuto; hover/focus `--poetheme-scroll-action-active-color` → colore CTA.
+
 ## 1.35.1
 - **Rimossa la "Dimensione testo (rem)" globale del contenuto:** la regola generata (`body.poetheme-has-font-settings` su body, form, `main p/li/ul/ol/dd/dt` e `.entry-content`) forzava un'unica dimensione su quasi tutto il testo, schiacciando ogni scala tipografica — plugin Palladio incluso. Il campo non viene più emesso né mostrato; l'eventuale valore salvato (`body_font_size`) resta nel database ma è inerte. La dimensione base torna quella del tema/CSS.
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.1
+Version: 1.35.2
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme
@@ -1915,7 +1915,10 @@ body.poetheme-mobile-drawer-open {
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 999px;
   background: #ffffff;
-  color: var(--poetheme-menu-link-color, #374151);
+  /* Colore dedicato: i cerchi sono bianchi, quindi NON deve seguire il colore
+   * dei link del menu (che palette come Sambiasi impostano chiaro per la
+   * testata scura, rendendo le icone invisibili quando non attive). */
+  color: var(--poetheme-scroll-action-color, var(--poetheme-content-text-color, #374151));
   box-shadow: 0 8px 24px rgba(17, 24, 39, 0.16);
   cursor: pointer;
   transition: background-color 150ms ease, color 150ms ease, transform 150ms ease;
@@ -1929,13 +1932,13 @@ body.poetheme-mobile-drawer-open {
 
 .poetheme-scroll-actions__toggle:hover,
 .poetheme-scroll-action:hover {
-  color: var(--poetheme-menu-active-link-color, #2563eb);
+  color: var(--poetheme-scroll-action-active-color, var(--poetheme-cta-background-color, #2563eb));
   transform: translateY(-1px);
 }
 
 .poetheme-scroll-actions__toggle:focus-visible,
 .poetheme-scroll-action:focus-visible {
-  outline: 2px solid var(--poetheme-menu-active-link-color, #2563eb);
+  outline: 2px solid var(--poetheme-scroll-action-active-color, var(--poetheme-cta-background-color, #2563eb));
   outline-offset: 2px;
 }
 
@@ -2056,7 +2059,9 @@ body.poetheme-mobile-drawer-open {
   text-decoration: none;
 }
 
-.poetheme-header--style-10__brand img {
+/* Senza "Altezza logo" configurata (stile inline dal tema) applica un tetto
+ * di cortesia; con l'opzione impostata vince la dimensione scelta in admin. */
+.poetheme-header--style-10__brand img:not([style]) {
   max-height: 3rem;
   width: auto;
 }


### PR DESCRIPTION
## Logo Style 10 — ridimensionamento corretto

Il tetto `max-height: 3rem` sul logo della testata Palladio · Sambiasi **sovrascriveva l'opzione "Altezza logo"** del tema (che viene applicata come stile inline `height:Xpx;width:auto`). Ora il tetto vale **solo per i loghi senza altezza configurata** (`img:not([style])`): con l'opzione impostata vince la dimensione scelta in admin, a proporzioni intatte.

## Icone scroll actions — colore non più sovrascritto

I pulsanti flottanti (torna su, commenti, condividi) usavano `--poetheme-menu-link-color`: con palette pensate per **testate scure** (come Sambiasi, dove i link del menu sono chiari) le icone diventavano **invisibili sui cerchi bianchi** nello stato non attivo — il colore "giusto" appariva solo in hover. Ora i colori sono **decoupled** con variabili dedicate:

- base: `--poetheme-scroll-action-color` → fallback colore testo del contenuto;
- hover/focus: `--poetheme-scroll-action-active-color` → fallback colore CTA.

Le nuove variabili sono sovrascrivibili dalle palette se in futuro si vuole personalizzarle.

## Verifica larghezza testata (nessuna modifica)

La barra Style 10 usa `.poetheme-container`, che segue `--poetheme-site-width` emessa **incondizionatamente** da "Larghezza sito" (Impostazioni globali): la testata è già allineata alla larghezza impostata. Nel layout **Full** il container è volutamente a tutta larghezza (regola `.poetheme-layout-full`), coerente col resto del sito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_