### PR TITLE
fix(css): rimosse le regole globali troppo invasive su testo e interlinea (v1.35.3)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.34.1' );
+define( 'POETHEME_VERSION', '1.35.3' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/fonts.php
+++ b/inc/admin/options/fonts.php
@@ -879,11 +879,10 @@ function poetheme_prepare_font_styles() {
         $css_rules .= $spacing_rules;
     }
 
+    // L'interlinea del corpo NON viene più emessa: la regola su
+    // body/main/p/li sovrascriveva anche i contenuti dei plugin
+    // (es. le pagine editoriali Palladio). Resta solo quella dei titoli.
     $line_height_rules = '';
-    $body_lh           = isset( $options['body_line_height'] ) ? $options['body_line_height'] : '';
-    if ( is_numeric( $body_lh ) && (float) $body_lh > 0 ) {
-        $line_height_rules .= 'body.poetheme-has-font-settings,body.poetheme-has-font-settings main,body.poetheme-has-font-settings main p,body.poetheme-has-font-settings main li{line-height:' . poetheme_format_number_for_css( $body_lh ) . ';}';
-    }
     $heading_lh = isset( $options['heading_line_height'] ) ? $options['heading_line_height'] : '';
     if ( is_numeric( $heading_lh ) && (float) $heading_lh > 0 ) {
         $line_height_rules .= 'body.poetheme-has-font-settings :where(h1,h2,h3,h4,h5,h6),body.poetheme-has-font-settings .poetheme-page-title,body.poetheme-has-font-settings .poetheme-post-title,body.poetheme-has-font-settings .poetheme-category-title{line-height:' . poetheme_format_number_for_css( $heading_lh ) . ';}';

--- a/inc/head-output.php
+++ b/inc/head-output.php
@@ -178,8 +178,10 @@ function poetheme_get_design_settings_css() {
 
     $styles .= 'body.poetheme-has-color-settings #primary-content .entry-content a{color:var(--poetheme-general-link-color) !important;}';
 
+    // Solo il colore base sul contenitore: la regola granulare con !important
+    // su p/li/span/td/th/dd/dt sovrascriveva anche gli stili dei plugin
+    // (es. le pagine editoriali Palladio) ed è stata rimossa.
     $styles .= 'body.poetheme-has-color-settings main{color:var(--poetheme-content-text-color) !important;}';
-    $styles .= 'body.poetheme-has-color-settings main p,body.poetheme-has-color-settings main li,body.poetheme-has-color-settings main span,body.poetheme-has-color-settings main td,body.poetheme-has-color-settings main th,body.poetheme-has-color-settings main dd,body.poetheme-has-color-settings main dt{color:var(--poetheme-content-text-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings main strong,body.poetheme-has-color-settings main b{color:var(--poetheme-content-strong-color) !important;}';
     $styles .= 'body.poetheme-has-color-settings main a{color:var(--poetheme-content-link-color) !important;text-decoration:var(--poetheme-content-link-decoration) !important;}';
     $styles .= 'body.poetheme-has-color-settings main a:hover,body.poetheme-has-color-settings main a:focus{color:var(--poetheme-content-link-color) !important;}';

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.2
+Version: 1.35.3
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

Rimosse due regole CSS generate dal tema che sovrascrivevano troppo (anche i contenuti dei plugin, es. le pagine editoriali Palladio):

1. **Colore testo granulare con `!important`** — `body.poetheme-has-color-settings main p, … li, span, td, th, dd, dt { color: var(--poetheme-content-text-color) !important; }` non viene più emessa (`inc/head-output.php`). Resta il colore base sul contenitore `main`, che i contenuti possono sovrascrivere normalmente.
2. **Interlinea del corpo** — `body.poetheme-has-font-settings, … main, main p, main li { line-height: … }` non viene più emessa (`inc/admin/options/fonts.php`). Resta l'interlinea dei titoli.

Versione: **1.35.3** (allineata anche `POETHEME_VERSION` in functions.php, rimasta ferma a 1.34.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_