### PR TITLE
fix(palladio): pagina Territorio riconosciuta come vista Palladio (v1.35.4)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.3' );
+define( 'POETHEME_VERSION', '1.35.4' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -442,7 +442,7 @@ function poetheme_get_layout_container_classes( $additional = array(), $include_
  * @return bool
  */
 function poetheme_is_palladio_request() {
-    $types = array( 'pll_edificio', 'pll_unita', 'pll_scenario', 'pll_storia' );
+    $types = array( 'pll_edificio', 'pll_unita', 'pll_scenario', 'pll_storia', 'pll_territorio' );
 
     if ( is_singular( $types ) || is_post_type_archive( $types ) ) {
         return true;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.3
+Version: 1.35.4
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

`poetheme_is_palladio_request()` non includeva `pll_territorio`: la pagina "Lecce e Salento" veniva resa **boxed** (container + `px-4 pt-10 pb-10` + sfondo del sito) invece che full-bleed come le altre pagine Palladio. Da qui i due difetti segnalati rispetto alla bozza grafica:
- **sfondo diverso** dalle altre pagine (si vedeva il background del tema attorno alle sezioni);
- **margine di troppo in testata** (il padding-top del container spingeva giù l'hero).

Aggiunto il post type all'elenco: ora la pagina Territorio usa `poetheme-palladio-main` (full-bleed, nessun padding) come Storia, Edificio, Unità e Scenari.

Versione: **1.35.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_