### PR TITLE
feat(schema): grafo JSON-LD allineato alle viste Palladio (v1.35.5)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.4' );
+define( 'POETHEME_VERSION', '1.35.5' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/schema.php
+++ b/inc/admin/schema.php
@@ -1333,6 +1333,13 @@ function poetheme_schema_output_jsonld() {
       'url'   => $canonical,
       'name'  => wp_get_document_title(),
     ) );
+  } elseif ( function_exists( 'palladio' ) && function_exists( 'poetheme_is_palladio_request' ) && poetheme_is_palladio_request() ) {
+    // Viste Palladio: il plugin emette il proprio grafo (RealEstateListing,
+    // ApartmentComplex, Offer, AboutPage...). Il tema aggiunge solo publisher
+    // e breadcrumb, senza duplicare il nodo pagina.
+    if ( $publisher_id ) {
+      $graph[] = $publisher;
+    }
   } else {
     $graph[] = poetheme_schema_filter_empty_values( array(
       '@type' => 'WebPage',

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.4
+Version: 1.35.5
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

Allineamento del modulo SEO Schema (JSON-LD) al caso d'uso Palladio: sulle pagine del plugin (edificio, unità, scenari, storia, territorio) il tema **non emette più il nodo `WebPage` generico** — il plugin (v0.30.0) pubblica il proprio grafo immobiliare (`RealEstateListing`, `ApartmentComplex`, `Offer`, `AboutPage`). Il tema su quelle pagine aggiunge il **publisher** (prima assente fuori da home e articoli) e la **breadcrumb**, così le due sorgenti si completano senza duplicare l'entità pagina.

Restano invariati: WebSite + publisher in home (anche quando la home è un edificio Palladio), Article sui post, CollectionPage sugli archivi (che il plugin integra con l'ItemList delle schede), e la disattivazione automatica in presenza di un plugin SEO dedicato.

Versione: **1.35.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_