### PR TITLE
fix(palladio): riconoscimento homepage-edificio via Impostazioni → Lettura (v1.35.6)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.5' );
+define( 'POETHEME_VERSION', '1.35.6' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -448,9 +448,15 @@ function poetheme_is_palladio_request() {
         return true;
     }
 
-    // Homepage servita dalla landing di un edificio Palladio.
-    if ( is_front_page() && (int) get_option( 'palladio_home_building', 0 ) > 0 ) {
-        return true;
+    // Homepage servita dalla landing di un edificio Palladio (standard
+    // WordPress: Impostazioni → Lettura; fallback sulla vecchia option).
+    if ( is_front_page() ) {
+        if ( function_exists( 'palladio_home_building_id' ) ) {
+            return palladio_home_building_id() > 0;
+        }
+        if ( (int) get_option( 'palladio_home_building', 0 ) > 0 ) {
+            return true;
+        }
     }
 
     return false;

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.5
+Version: 1.35.6
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

`poetheme_is_palladio_request()` riconosce la homepage-edificio tramite il nuovo helper del plugin `palladio_home_building_id()` (che legge le option standard `show_on_front`/`page_on_front` di Impostazioni → Lettura, introdotte in Palladio v0.31.0), con fallback sulla vecchia option `palladio_home_building` se il plugin attivo è una versione precedente.

Versione: **1.35.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_