### PR TITLE
fix(schema): rilevamento All in One SEO (v1.35.7)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.6' );
+define( 'POETHEME_VERSION', '1.35.7' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/schema.php
+++ b/inc/admin/schema.php
@@ -1065,6 +1065,8 @@ function poetheme_schema_has_seo_plugin() {
     || defined( 'SEOPRESS_VERSION' )
     || function_exists( 'seopress_get_service' )
     || class_exists( 'SEOPress\\Main\\WP' )
+    || defined( 'AIOSEO_VERSION' )
+    || function_exists( 'aioseo' )
   );
 }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.6
+Version: 1.35.7
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

`poetheme_schema_has_seo_plugin()` riconosce anche **All in One SEO** (`AIOSEO_VERSION` / `aioseo()`): con AIOSEO attivo il grafo JSON-LD del tema (WebSite/publisher/breadcrumb) si disattiva automaticamente, come già avviene con Yoast, Rank Math e SEOPress — niente entità duplicate nei rich results.

Versione: **1.35.7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_