### PR TITLE
feat(header): CTA traducibile e ancorata al form contatti della pagina corrente (v1.35.8)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.7' );
+define( 'POETHEME_VERSION', '1.35.8' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/admin/options/header.php
+++ b/inc/admin/options/header.php
@@ -392,7 +392,8 @@ function poetheme_render_header_page() {
                             <label for="poetheme_header_cta_text" class="screen-reader-text"><?php esc_html_e( 'Testo pulsante', 'poetheme' ); ?></label>
                             <input type="text" id="poetheme_header_cta_text" name="poetheme_header[cta_text]" value="<?php echo esc_attr( $options['cta_text'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Get Started', 'poetheme' ); ?>" />
                             <label for="poetheme_header_cta_url" class="screen-reader-text"><?php esc_html_e( 'Link pulsante', 'poetheme' ); ?></label>
-                            <input type="url" id="poetheme_header_cta_url" name="poetheme_header[cta_url]" value="<?php echo esc_attr( $options['cta_url'] ); ?>" class="regular-text" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
+                            <input type="text" id="poetheme_header_cta_url" name="poetheme_header[cta_url]" value="<?php echo esc_attr( $options['cta_url'] ); ?>" class="regular-text" placeholder="#palladio-contact" />
+                            <p class="description"><?php esc_html_e( 'URL completo, percorso relativo o àncora. Con “#palladio-contact” il pulsante salta al modulo contatti della pagina corrente, in qualunque lingua.', 'poetheme' ); ?></p>
                         </td>
                     </tr>
                     <tr class="poetheme-field">

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -967,11 +967,26 @@ function poetheme_get_header_context() {
     }
 
     $cta_text = isset( $options['cta_text'] ) ? sanitize_text_field( $options['cta_text'] ) : '';
-    $cta_url  = '';
+
+    // Etichetta CTA tradotta nella lingua della pagina (dizionario Palladio
+    // "Testi statici"): il valore è un'opzione, non passa da gettext.
+    if ( '' !== $cta_text && ! is_admin() && class_exists( 'Palladio_I18n_Strings' ) ) {
+        $cta_text = Palladio_I18n_Strings::translate_text( $cta_text );
+    }
+
+    $cta_url = '';
     if ( ! empty( $options['cta_url'] ) ) {
         $cta_url = $options['cta_url'];
     } elseif ( ! empty( $cta_text ) ) {
         $cta_url = home_url( '/' );
+    }
+
+    // CTA verso il modulo contatti Palladio: se l'URL termina con l'àncora
+    // #palladio-contact (o è solo l'àncora), il link resta nella PAGINA
+    // CORRENTE — così salta al form nella lingua giusta, senza tornare
+    // alla home italiana.
+    if ( $cta_url && '#palladio-contact' === substr( $cta_url, -17 ) ) {
+        $cta_url = '#palladio-contact';
     }
 
     $social_links = array();

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.7
+Version: 1.35.8
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Cosa cambia

Analisi della Call to Action dell'header: l'etichetta è un **valore di opzione** (non gettext, quindi mai tradotta) e il campo "Link pulsante" era `type="url"` — il browser rifiutava valori come `#palladio-contact`, obbligando all'URL completo che riportava sempre alla pagina italiana.

### Soluzione
1. **Campo link libero** — accetta URL completi, percorsi relativi e àncore (`type="text"` + `esc_url_raw`, che le preserva). Placeholder e descrizione suggeriscono `#palladio-contact`.
2. **Ancora "viva" sulla pagina corrente** — se l'URL della CTA termina con `#palladio-contact` (o è solo l'àncora), il link renderizzato diventa `#palladio-contact` puro: **salta al modulo contatti presente nella pagina che stai guardando**, in qualunque lingua — il form Palladio è su tutte le pagine, quindi l'àncora è sempre valida.
3. **Etichetta tradotta** — il testo della CTA passa dal dizionario **Testi statici** di Palladio nella lingua della pagina (`Palladio_I18n_Strings::translate_text`, con guardia `class_exists`: il tema funziona anche senza plugin). Se l'etichetta personalizzata non è ancora tradotta, compare da sola nel catalogo Testi statici pronta per la traduzione manuale o AI. Centralizzato in `poetheme_get_header_context()`: vale per **tutti gli stili di header**, non solo Style 10.

Versione: **1.35.8**. Da abbinare a Palladio v0.39.0 (traduzione termini tassonomie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_