### PR TITLE
fix(custom css): visibile a tutti i visitatori, non solo agli admin (v1.35.9)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @package PoeTheme
  */
 
-define( 'POETHEME_VERSION', '1.35.8' );
+define( 'POETHEME_VERSION', '1.35.9' );
 
 define( 'POETHEME_DIR', get_template_directory() );
 define( 'POETHEME_URI', get_template_directory_uri() );

--- a/inc/head-output.php
+++ b/inc/head-output.php
@@ -324,10 +324,6 @@ function poetheme_get_design_settings_css() {
  * @return string
  */
 function poetheme_get_custom_css() {
-    if ( ! poetheme_user_can_manage_options() ) {
-        return '';
-    }
-
     $custom_css = get_option( 'poetheme_custom_css', '' );
 
     if ( empty( $custom_css ) ) {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://example.com/poetheme
 Author: Cosè Murciano
 Author URI: https://example.com
 Description: Tema WordPress moderno con supporto completo per Gutenberg, accessibilità e SEO ottimizzata.
-Version: 1.35.8
+Version: 1.35.9
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: poetheme


### PR DESCRIPTION
## Problema

Il **Custom CSS** di PoeTheme era visibile solo agli utenti loggati con capability `manage_options`: per tutti i visitatori anonimi (e per gli utenti non admin) il blocco `<style>` non veniva proprio stampato nell'HTML. Non era un problema di cache.

## Causa

In `inc/head-output.php`, `poetheme_get_custom_css()` iniziava con:

```php
if ( ! poetheme_user_can_manage_options() ) {
    return '';
}
```

Il controllo di capability è corretto **in fase di salvataggio** dell'opzione (già presente in `poetheme_sanitize_custom_css()` in `inc/security.php`), ma applicato **in fase di output** escludeva il CSS personalizzato per chiunque non fosse amministratore.

## Fix

- Rimosso il guard di capability da `poetheme_get_custom_css()`: l'output del Custom CSS ora dipende solo dal valore dell'opzione, sanitizzato come prima da `poetheme_sanitize_inline_css()`.
- Verificati tutti gli altri usi di `poetheme_user_can_manage_options()`: sono su salvataggi e pagine admin, quindi corretti e invariati.

Versione tema: **1.35.9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfsLPVCGvqe38unBAUzVsn)_